### PR TITLE
Fix docs typos, sidebar path check and improve tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,14 +188,14 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `customProps`        | `object`  | `null`  | Additional props for customizing a sidebar item.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `sidebarGenerators`  | `object`  | `null`  | Optional: Customize sidebar rendering with callback functions.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 
-> You may optionally configure a `sidebarOptions`. In doing so, an individual `sidebar.js` slice with the configured options will be generated within the respective `outputDir`.
+> You may optionally configure a `sidebarOptions`. In doing so, an individual `sidebar.ts` slice with the configured options will be generated within the respective `outputDir`.
 
 `versions` can be configured with the following options:
 
 | Name          | Type     | Default | Description                                                                                                              |
 | ------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `specPath`    | `string` | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of micro OpenAPI specification files. |
-| `ouputDir`    | `string` | `null`  | Desired output path for versioned, generated MDX files.                                                                  |
+| `outputDir`   | `string` | `null`  | Desired output path for versioned, generated MDX files.                                                                  |
 | `label`       | `string` | `null`  | _Optional:_ Version label used when generating version selector dropdown menu.                                           |
 | `baseUrl`     | `string` | `null`  | _Optional:_ Version base URL used when generating version selector dropdown menu.                                        |
 | `downloadUrl` | `string` | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification for versioned.                                          |

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -216,14 +216,14 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `customProps`        | `object`  | `null`  | Additional props for customizing a sidebar item.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `sidebarGenerators`  | `object`  | `null`  | Optional: Customize sidebar rendering with callback functions.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 
-> You may optionally configure a `sidebarOptions`. In doing so, an individual `sidebar.js` slice with the configured options will be generated within the respective `outputDir`.
+> You may optionally configure a `sidebarOptions`. In doing so, an individual `sidebar.ts` slice with the configured options will be generated within the respective `outputDir`.
 
 `versions` can be configured with the following options:
 
 | Name       | Type     | Default | Description                                                                                                              |
 | ---------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `specPath` | `string` | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of micro OpenAPI specification files. |
-| `ouputDir` | `string` | `null`  | Desired output path for versioned, generated MDX files.                                                                  |
+| `outputDir` | `string` | `null`  | Desired output path for versioned, generated MDX files.                                                                  |
 | `label`    | `string` | `null`  | _Optional:_ Version label used when generating version selector dropdown menu.                                           |
 | `baseUrl`  | `string` | `null`  | _Optional:_ Version base URL used when generating version selector dropdown menu.                                        |
 

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -188,16 +188,16 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `customProps`        | `object`  | `null`  | Additional props for customizing a sidebar item.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `sidebarGenerators`  | `object`  | `null`  | Optional: Customize sidebar rendering with callback functions.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 
-> You may optionally configure a `sidebarOptions`. In doing so, an individual `sidebar.js` slice with the configured options will be generated within the respective `outputDir`.
+> You may optionally configure a `sidebarOptions`. In doing so, an individual `sidebar.ts` slice with the configured options will be generated within the respective `outputDir`.
 
 `versions` can be configured with the following options:
 
-| Name       | Type     | Default | Description                                                                                                              |
-| ---------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `specPath` | `string` | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of micro OpenAPI specification files. |
-| `ouputDir` | `string` | `null`  | Desired output path for versioned, generated MDX files.                                                                  |
-| `label`    | `string` | `null`  | _Optional:_ Version label used when generating version selector dropdown menu.                                           |
-| `baseUrl`  | `string` | `null`  | _Optional:_ Version base URL used when generating version selector dropdown menu.                                        |
+| Name        | Type     | Default | Description                                                                                                              |
+| ----------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `specPath`  | `string` | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of micro OpenAPI specification files. |
+| `outputDir` | `string` | `null`  | Desired output path for versioned, generated MDX files.                                                                  |
+| `label`     | `string` | `null`  | _Optional:_ Version label used when generating version selector dropdown menu.                                           |
+| `baseUrl`   | `string` | `null`  | _Optional:_ Version base URL used when generating version selector dropdown menu.                                        |
 
 > All versions will automatically inherit `sidebarOptions` from the parent/base config.
 

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -65,7 +65,8 @@ const createDocItem: ApiDocItemGenerator = (
         );
   return {
     type: "doc" as const,
-    id: basePath === "" || undefined ? `${id}` : `${basePath}/${id}`,
+    id:
+      basePath === "" || basePath === undefined ? `${id}` : `${basePath}/${id}`,
     label: (sidebar_label as string) ?? title ?? id,
     customProps: customProps,
     className: className ? className : undefined,
@@ -142,7 +143,10 @@ function groupByTags(
     const id = infoItem.id;
     rootIntroDoc = {
       type: "doc" as const,
-      id: basePath === "" || undefined ? `${id}` : `${basePath}/${id}`,
+      id:
+        basePath === "" || basePath === undefined
+          ? `${id}`
+          : `${basePath}/${id}`,
     };
   }
 
@@ -167,7 +171,7 @@ function groupByTags(
         linkConfig = {
           type: "doc",
           id:
-            basePath === "" || undefined
+            basePath === "" || basePath === undefined
               ? `${taggedInfoObject.id}`
               : `${basePath}/${taggedInfoObject.id}`,
         } as SidebarItemCategoryLinkConfig;
@@ -179,7 +183,9 @@ function groupByTags(
         linkConfig = {
           type: "doc",
           id:
-            basePath === "" || undefined ? `${tagId}` : `${basePath}/${tagId}`,
+            basePath === "" || basePath === undefined
+              ? `${tagId}`
+              : `${basePath}/${tagId}`,
         } as SidebarItemCategoryLinkConfig;
       }
 

--- a/packages/docusaurus-theme-openapi-docs/src/markdown/utils.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/markdown/utils.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import { guard } from "./utils";
+import { guard, create, render } from "./utils";
 
 describe("guard", () => {
   it("should guard empty strings", () => {
@@ -45,5 +45,24 @@ describe("guard", () => {
   it("should not guard true booleans", () => {
     const actual = guard(true, (value) => `${value}`);
     expect(actual).toBe("true");
+  });
+});
+
+describe("create", () => {
+  it("should create element with props and children", () => {
+    const actual = create("div", { className: "x", children: "hello" });
+    expect(actual).toBe('<div className={"x"}>hello</div>');
+  });
+});
+
+describe("render", () => {
+  it("should render arrays while filtering undefined", () => {
+    const actual = render(["a", undefined, "b"]);
+    expect(actual).toBe("ab");
+  });
+
+  it("should render undefined as empty string", () => {
+    const actual = render(undefined);
+    expect(actual).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- fix documentation references to `outputDir` and `sidebar.ts`
- correct sidebar basePath checks
- add tests for `create` and `render` helpers

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684b541982b083239e1ad7d36dd19d69