### PR TITLE
Add comprehensive test examples

### DIFF
--- a/demo/examples/tests/allOf.yaml
+++ b/demo/examples/tests/allOf.yaml
@@ -299,15 +299,6 @@ paths:
 
 components:
   schemas:
-    # Your existing schemas are integrated here.
-    ExistingSchema1:
-      type: object
-      properties: ...
-
-    ExistingSchema2:
-      type: object
-      properties: ...
-
     # New schemas for Books demonstration
     BookBase:
       type: object

--- a/demo/examples/tests/callbacks.yaml
+++ b/demo/examples/tests/callbacks.yaml
@@ -1,0 +1,68 @@
+openapi: 3.0.1
+info:
+  title: Callback Example API
+  description: Demonstrates callback usage.
+  version: 1.0.0
+tags:
+  - name: callbacks
+    description: callback tests
+paths:
+  /streams:
+    post:
+      tags:
+        - callbacks
+      summary: Subscribe for stream events
+      description: |
+        This endpoint registers for stream events.
+
+        Schema:
+        ```yaml
+        callbacks:
+          onEvent:
+            '{$request.body#/callbackUrl}':
+              post:
+                requestBody:
+                  description: Callback payload
+                  required: true
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                responses:
+                  '200':
+                    description: Callback accepted
+        ```
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                callbackUrl:
+                  type: string
+              required:
+                - callbackUrl
+      callbacks:
+        onEvent:
+          "{$request.body#/callbackUrl}":
+            post:
+              requestBody:
+                description: Callback payload
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        message:
+                          type: string
+              responses:
+                "200":
+                  description: Callback accepted
+      responses:
+        "201":
+          description: Subscription created

--- a/demo/examples/tests/conditionals.yaml
+++ b/demo/examples/tests/conditionals.yaml
@@ -1,0 +1,100 @@
+openapi: 3.1.0
+info:
+  title: Conditional and Prefix Items API
+  description: Demonstrates if/then/else and prefixItems usage.
+  version: 1.0.0
+tags:
+  - name: advanced
+    description: conditional and array tests
+paths:
+  /conditional-object:
+    get:
+      tags:
+        - advanced
+      summary: Conditional schema with if/then/else
+      description: |
+        This endpoint validates an object with conditional logic.
+
+        Schema:
+        ```yaml
+        type: object
+        properties:
+          type:
+            type: string
+        if:
+          properties:
+            type:
+              const: special
+        then:
+          required: [specialProp]
+          properties:
+            specialProp:
+              type: string
+        else:
+          properties:
+            otherProp:
+              type: integer
+        example:
+          type: special
+          specialProp: "value"
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                if:
+                  properties:
+                    type:
+                      const: special
+                then:
+                  required:
+                    - specialProp
+                  properties:
+                    specialProp:
+                      type: string
+                else:
+                  properties:
+                    otherProp:
+                      type: integer
+                example:
+                  type: special
+                  specialProp: "value"
+  /fixed-array:
+    get:
+      tags:
+        - advanced
+      summary: Array with prefixItems
+      description: |
+        This endpoint demonstrates the prefixItems feature.
+
+        Schema:
+        ```yaml
+        type: array
+        prefixItems:
+          - type: string
+          - type: integer
+        items: false
+        example:
+          - "name"
+          - 1
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                prefixItems:
+                  - type: string
+                  - type: integer
+                items: false
+                example:
+                  - "name"
+                  - 1

--- a/demo/examples/tests/enumDescriptions.yaml
+++ b/demo/examples/tests/enumDescriptions.yaml
@@ -12,7 +12,25 @@ paths:
       tags:
         - enumDescriptions
       summary: Get entities by status
-      description: Get all entities or search by status
+      description: |
+        Get all entities or search by status.
+
+        Schema:
+        ```yaml
+        status:
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - active
+              - inactive
+              - pending
+            x-enumDescriptions:
+              active: The entity is active
+              inactive: The entity is inactive
+              pending: The entity is pending approval
+        ```
       parameters:
         - name: status
           in: query
@@ -39,7 +57,27 @@ paths:
       tags:
         - enumDescriptions
       summary: Get entities by multiple status
-      description: Get all entities or search by multiple status
+      description: |
+        Get all entities or search by multiple status.
+
+        Schema:
+        ```yaml
+        status:
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - active
+                - inactive
+                - pending
+              x-enumDescriptions:
+                active: The entity is active
+                inactive: The entity is inactive
+                pending: The entity is pending approval
+        ```
       parameters:
         - name: status
           in: query

--- a/demo/examples/tests/examples.yaml
+++ b/demo/examples/tests/examples.yaml
@@ -1,0 +1,57 @@
+openapi: 3.0.2
+info:
+  title: Multiple Examples API
+  description: Demonstrates the `examples` field.
+  version: 1.0.0
+tags:
+  - name: examples
+    description: examples tests
+paths:
+  /color:
+    get:
+      tags:
+        - examples
+      summary: Parameter with multiple examples
+      description: |
+        Provides color information.
+
+        Schema:
+        ```yaml
+        parameters:
+          - name: palette
+            in: query
+            schema:
+              type: string
+            examples:
+              primary:
+                value: red
+              secondary:
+                value: blue
+        ```
+      parameters:
+        - name: palette
+          in: query
+          schema:
+            type: string
+          examples:
+            primary:
+              value: red
+            secondary:
+              value: blue
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  palette:
+                    type: string
+              examples:
+                primary:
+                  value:
+                    palette: red
+                secondary:
+                  value:
+                    palette: blue

--- a/demo/examples/tests/formatStrings.yaml
+++ b/demo/examples/tests/formatStrings.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.3
+info:
+  title: Format Strings API
+  description: Demonstrates various string formats.
+  version: 1.0.0
+tags:
+  - name: formats
+    description: format tests
+paths:
+  /string-formats:
+    get:
+      tags:
+        - formats
+      summary: Strings with format validation
+      description: |
+        This endpoint returns strings in different formats.
+
+        Schema:
+        ```yaml
+        type: object
+        properties:
+          uuid:
+            type: string
+            format: uuid
+          email:
+            type: string
+            format: email
+        example:
+          uuid: "123e4567-e89b-12d3-a456-426614174000"
+          email: "user@example.com"
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                    format: uuid
+                  email:
+                    type: string
+                    format: email
+                example:
+                  uuid: "123e4567-e89b-12d3-a456-426614174000"
+                  email: "user@example.com"

--- a/demo/examples/tests/links.yaml
+++ b/demo/examples/tests/links.yaml
@@ -1,0 +1,65 @@
+openapi: 3.0.2
+info:
+  title: Links Example API
+  description: Demonstrates response links.
+  version: 1.0.0
+tags:
+  - name: links
+    description: link tests
+paths:
+  /users/{userId}:
+    get:
+      tags:
+        - links
+      summary: Get user by ID
+      description: |
+        Retrieves a user and provides a link to their posts.
+
+        Schema:
+        ```yaml
+        responses:
+          '200':
+            links:
+              UserPosts:
+                operationId: getUserPosts
+                parameters:
+                  userId: '$response.body#/id'
+        ```
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: A user object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+          links:
+            UserPosts:
+              operationId: getUserPosts
+              parameters:
+                userId: "$response.body#/id"
+  /users/{userId}/posts:
+    get:
+      tags:
+        - links
+      summary: Get posts for user
+      description: Return posts for the given user ID.
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: A list of posts

--- a/demo/examples/tests/minmax.yaml
+++ b/demo/examples/tests/minmax.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.2
+info:
+  title: MinMax Constraints API
+  description: Demonstrates min and max numeric constraints.
+  version: 1.0.0
+tags:
+  - name: minmax
+    description: min and max tests
+paths:
+  /age-range:
+    get:
+      tags:
+        - minmax
+      summary: Age range with minimum and maximum
+      description: |
+        This endpoint returns an object with numeric boundaries.
+
+        Schema:
+        ```yaml
+        type: object
+        properties:
+          age:
+            type: integer
+            minimum: 18
+            maximum: 65
+        required:
+          - age
+        example:
+          age: 30
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  age:
+                    type: integer
+                    minimum: 18
+                    maximum: 65
+                required:
+                  - age
+                example:
+                  age: 30

--- a/demo/examples/tests/nullableExclusive.yaml
+++ b/demo/examples/tests/nullableExclusive.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.2
+info:
+  title: Nullable and Exclusive Numeric Bounds API
+  description: Demonstrates nullable fields with exclusive minimum and maximum.
+  version: 1.0.0
+tags:
+  - name: nullableExclusive
+    description: nullable and exclusive bound tests
+paths:
+  /nullable-number:
+    get:
+      tags:
+        - nullableExclusive
+      summary: Nullable number with exclusive bounds
+      description: |
+        This endpoint returns a nullable number using exclusive limits.
+
+        Schema:
+        ```yaml
+        type: object
+        properties:
+          score:
+            type: number
+            nullable: true
+            minimum: 0
+            exclusiveMinimum: true
+            maximum: 100
+            exclusiveMaximum: true
+        required:
+          - score
+        example:
+          score: 50
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  score:
+                    type: number
+                    nullable: true
+                    minimum: 0
+                    exclusiveMinimum: true
+                    maximum: 100
+                    exclusiveMaximum: true
+                required:
+                  - score
+                example:
+                  score: 50

--- a/demo/examples/tests/security.yaml
+++ b/demo/examples/tests/security.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.4
+info:
+  title: Security Schemes API
+  description: Demonstrates HTTP basic and API key authentication.
+  version: 1.0.0
+tags:
+  - name: security
+    description: security tests
+paths:
+  /protected-basic:
+    get:
+      tags:
+        - security
+      summary: Basic auth protected endpoint
+      description: |
+        Requires HTTP basic authentication.
+
+        Schema:
+        ```yaml
+        security:
+          - BasicAuth: []
+        ```
+      security:
+        - BasicAuth: []
+      responses:
+        "200":
+          description: Authorized
+  /protected-apikey:
+    get:
+      tags:
+        - security
+      summary: API key protected endpoint
+      description: |
+        Requires an API key in the header.
+
+        Schema:
+        ```yaml
+        security:
+          - ApiKeyAuth: []
+        ```
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: Authorized
+components:
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key

--- a/demo/examples/tests/servers.yaml
+++ b/demo/examples/tests/servers.yaml
@@ -1,0 +1,48 @@
+openapi: 3.1.0
+info:
+  title: Server Variables API
+  description: Demonstrates servers object with variables.
+  version: 1.0.0
+tags:
+  - name: servers
+    description: server variable tests
+servers:
+  - url: https://{region}.api.example.com/v1
+    description: Main server
+    variables:
+      region:
+        default: us
+        enum:
+          - us
+          - eu
+          - ap
+paths:
+  /info:
+    get:
+      tags:
+        - servers
+      summary: Example using server variables
+      description: |
+        Access API information.
+
+        Schema:
+        ```yaml
+        servers:
+          - url: https://{region}.api.example.com/v1
+            variables:
+              region:
+                default: us
+                enum: [us, eu, ap]
+        ```
+      responses:
+        "200":
+          description: OK
+      servers:
+        - url: https://{region}.api.example.com/v1/info
+          variables:
+            region:
+              default: us
+              enum:
+                - us
+                - eu
+                - ap

--- a/demo/examples/tests/webhooks.yaml
+++ b/demo/examples/tests/webhooks.yaml
@@ -1,0 +1,65 @@
+openapi: 3.1.0
+info:
+  title: Webhooks Example API
+  description: Demonstrates the webhooks object.
+  version: 1.0.0
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+tags:
+  - name: webhooks
+    description: webhook tests
+paths:
+  /register:
+    post:
+      tags:
+        - webhooks
+      summary: Register a webhook
+      description: |
+        Registers a webhook URL which will be called on events.
+
+        Schema:
+        ```yaml
+        webhooks:
+          onNotify:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        message:
+                          type: string
+              responses:
+                '200':
+                  description: Hook processed
+        ```
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+              required:
+                - url
+      responses:
+        "200":
+          description: Registered
+webhooks:
+  onNotify:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+      responses:
+        "200":
+          description: Hook processed


### PR DESCRIPTION
## Summary
- add spec demonstrating security schemes with HTTP Basic and API key
- add server variables example
- showcase parameters and responses using `examples` field

## Testing
- `yarn format`
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684b5419c6f48323b396e50e24bbdfd6