### PR TITLE
Fix CopyButton props import

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ApiCodeBlock/CopyButton/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ApiCodeBlock/CopyButton/index.tsx
@@ -7,10 +7,14 @@
 
 import React, { useCallback, useState, useRef, useEffect } from "react";
 
-import { CopyButtonProps } from "@docusaurus/theme-common/internal";
 import { translate } from "@docusaurus/Translate";
+import type { Props as BaseCopyButtonProps } from "@theme/CodeBlock/CopyButton";
 import clsx from "clsx";
 import copy from "copy-text-to-clipboard";
+
+export interface CopyButtonProps extends BaseCopyButtonProps {
+  code: string;
+}
 
 export default function CopyButton({
   code,


### PR DESCRIPTION
## Summary
- align ApiExplorer CopyButton with latest Docusaurus by using `@theme/CodeBlock/CopyButton` props

## Testing
- `yarn lint`
- `yarn test`
- `yarn build-packages`


------
https://chatgpt.com/codex/tasks/task_e_685ef36ffe40832393377cbebe924e4e