### PR TITLE
Fix postman object handling in ApiExplorer

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/index.tsx
@@ -22,7 +22,11 @@ function ApiExplorer({
   infoPath: string;
 }) {
   const postman = new sdk.Request(
-    item.postman ? (item.postman as any).toJSON() : {}
+    item.postman
+      ? sdk.Request.isRequest(item.postman)
+        ? (item.postman as any).toJSON()
+        : (item.postman as any)
+      : {}
   );
 
   return (


### PR DESCRIPTION
## Summary
- ensure `ApiExplorer` accepts plain postman objects

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_685f09bf7ba08323bf3ecd5b904244f8