### PR TITLE
Add concurrency to visual diff script

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -177,7 +177,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run visual diff
-        run: yarn ts-node scripts/sitemap-visual-diff.ts --preview-url ${{ needs.deploy.outputs.preview_url }} --summary-file visual_diffs/results.json
+        run: yarn ts-node scripts/sitemap-visual-diff.ts --preview-url ${{ needs.deploy.outputs.preview_url }} --summary-file visual_diffs/results.json --concurrency 4
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()

--- a/scripts/sitemap-visual-diff.ts
+++ b/scripts/sitemap-visual-diff.ts
@@ -20,6 +20,7 @@ interface Options {
   tolerance: number;
   width: number;
   viewHeight: number;
+  concurrency: number;
   summaryFile: string;
 }
 
@@ -31,6 +32,7 @@ function parseArgs(): Options {
     tolerance: 0,
     width: 1280,
     viewHeight: 1024,
+    concurrency: 4,
     summaryFile: "visual_diffs/results.json",
   };
   for (let i = 0; i < args.length; i++) {
@@ -55,6 +57,10 @@ function parseArgs(): Options {
       case "-v":
       case "--view-height":
         opts.viewHeight = Number(args[++i]);
+        break;
+      case "-c":
+      case "--concurrency":
+        opts.concurrency = Number(args[++i]);
         break;
       case "-s":
       case "--summary-file":
@@ -125,6 +131,25 @@ function compareImages(
   return true;
 }
 
+async function promisePool<T>(
+  items: T[],
+  concurrency: number,
+  iteratorFn: (item: T) => Promise<void>
+) {
+  const executing: Promise<void>[] = [];
+
+  for (const item of items) {
+    const p = iteratorFn(item).then(() => {
+      executing.splice(executing.indexOf(p), 1);
+    });
+    executing.push(p);
+    if (executing.length >= concurrency) {
+      await Promise.race(executing);
+    }
+  }
+  await Promise.all(executing);
+}
+
 async function run() {
   const opts = parseArgs();
   if (!opts.previewUrl) {
@@ -132,7 +157,9 @@ async function run() {
   }
   if (!opts.previewUrl.endsWith("/")) opts.previewUrl += "/";
 
-  const sitemapXml = await fetchSitemap("https://docusaurus-openapi.tryingpan.dev/sitemap.xml");
+  const sitemapXml = await fetchSitemap(
+    "https://docusaurus-openapi.tryingpan.dev/sitemap.xml"
+  );
   const paths = parseUrlsFromSitemap(await sitemapXml);
   console.log(`Found ${paths.length} paths.`);
 
@@ -140,21 +167,20 @@ async function run() {
   const context = await browser.newContext({
     viewport: { width: opts.width, height: opts.viewHeight },
   });
-  const page = await context.newPage();
-
   let total = 0;
   let matches = 0;
   let mismatches = 0;
   let skipped = 0;
   const pages: { path: string; status: string }[] = [];
 
-  for (const url of paths) {
+  async function processPath(url: string) {
     total += 1;
     const cleanPath =
       new URL(url).pathname.replace(/^\//, "").replace(/\/$/, "") || "root";
     const prodSnap = path.join(opts.outputDir, "prod", `${cleanPath}.png`);
     const prevSnap = path.join(opts.outputDir, "preview", `${cleanPath}.png`);
     const diffImg = path.join(opts.outputDir, "diff", `${cleanPath}.png`);
+    const page = await context.newPage();
     try {
       await screenshotFullPage(page, url, prodSnap);
       await screenshotFullPage(
@@ -176,7 +202,10 @@ async function run() {
       skipped += 1;
       pages.push({ path: `/${cleanPath}`, status: "skip" });
     }
+    await page.close();
   }
+
+  await promisePool(paths, opts.concurrency, processPath);
 
   await browser.close();
   console.log(

--- a/scripts/sitemap-visual-diff.ts
+++ b/scripts/sitemap-visual-diff.ts
@@ -21,6 +21,7 @@ interface Options {
   width: number;
   viewHeight: number;
   concurrency: number;
+  diffAlpha: number;
   summaryFile: string;
 }
 
@@ -33,6 +34,7 @@ function parseArgs(): Options {
     width: 1280,
     viewHeight: 1024,
     concurrency: 4,
+    diffAlpha: 1,
     summaryFile: "visual_diffs/results.json",
   };
   for (let i = 0; i < args.length; i++) {
@@ -61,6 +63,10 @@ function parseArgs(): Options {
       case "-c":
       case "--concurrency":
         opts.concurrency = Number(args[++i]);
+        break;
+      case "-a":
+      case "--diff-alpha":
+        opts.diffAlpha = Number(args[++i]);
         break;
       case "-s":
       case "--summary-file":
@@ -104,7 +110,8 @@ function compareImages(
   prodPath: string,
   prevPath: string,
   diffPath: string,
-  tolerance: number
+  tolerance: number,
+  diffAlpha: number
 ): boolean {
   const prod = PNG.sync.read(fs.readFileSync(prodPath));
   const prev = PNG.sync.read(fs.readFileSync(prevPath));
@@ -121,6 +128,7 @@ function compareImages(
     prod.height,
     {
       threshold: tolerance,
+      alpha: diffAlpha,
     }
   );
   if (numDiff > 0) {
@@ -188,7 +196,15 @@ async function run() {
         new URL(cleanPath, opts.previewUrl).toString(),
         prevSnap
       );
-      if (compareImages(prodSnap, prevSnap, diffImg, opts.tolerance)) {
+      if (
+        compareImages(
+          prodSnap,
+          prevSnap,
+          diffImg,
+          opts.tolerance,
+          opts.diffAlpha
+        )
+      ) {
         console.log(`MATCH: /${cleanPath}`);
         matches += 1;
         pages.push({ path: `/${cleanPath}`, status: "match" });


### PR DESCRIPTION
## Summary
- allow concurrent visual diffing using a promise pool
- expose concurrency option via CLI and default to 4
- run workflow step with concurrency flag

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68630955cc9083239d52b7d08e3acdec