### PR TITLE
Handle webhooks missing summary

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/__fixtures__/webhook/openapi.yaml
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/__fixtures__/webhook/openapi.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Webhook Example
+  version: 1.0.0
+paths: {}
+webhooks:
+  order.created:
+    post:
+      requestBody:
+        description: example body
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: OK

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -274,11 +274,19 @@ function createItems(
   for (let [path, pathObject] of Object.entries(
     openapiData["x-webhooks"] ?? openapiData["webhooks"] ?? {}
   )) {
+    const eventName = path;
     path = "webhook";
     const { $ref, description, parameters, servers, summary, ...rest } =
       pathObject;
     for (let [method, operationObject] of Object.entries({ ...rest })) {
       method = "event";
+      if (
+        operationObject.summary === undefined &&
+        operationObject.operationId === undefined
+      ) {
+        operationObject.summary = eventName;
+      }
+
       const title =
         operationObject.summary ??
         operationObject.operationId ??
@@ -290,7 +298,7 @@ function createItems(
 
       const baseId = operationObject.operationId
         ? kebabCase(operationObject.operationId)
-        : kebabCase(operationObject.summary);
+        : kebabCase(operationObject.summary ?? eventName);
 
       const extensions = [];
       const commonExtensions = ["x-codeSamples"];

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/webhooks.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/webhooks.test.ts
@@ -1,0 +1,30 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import path from "path";
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { posixPath } from "@docusaurus/utils";
+
+import { readOpenapiFiles, processOpenapiFiles } from ".";
+
+describe("webhooks", () => {
+  it("uses event name when summary and operationId are missing", async () => {
+    const files = await readOpenapiFiles(
+      posixPath(path.join(__dirname, "__fixtures__/webhook/openapi.yaml"))
+    );
+
+    const [items] = await processOpenapiFiles(
+      files,
+      { specPath: "", outputDir: "" } as any,
+      {}
+    );
+
+    const webhookItem = items.find((item) => item.type === "api");
+    expect(webhookItem?.id).toBe("order-created");
+  });
+});


### PR DESCRIPTION
## Summary
- use webhook event name when summary/operationId is missing
- add fixture and unit test for webhook event name fallback

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6865430243408323a51d3515d4a58799