### PR TITLE
Add Markdown DocCard override

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/DocCard/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/DocCard/index.tsx
@@ -1,0 +1,142 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import React, { type ReactNode } from "react";
+
+import isInternalUrl from "@docusaurus/isInternalUrl";
+import Link from "@docusaurus/Link";
+import type {
+  PropSidebarItemCategory,
+  PropSidebarItemLink,
+} from "@docusaurus/plugin-content-docs";
+import {
+  useDocById,
+  findFirstSidebarItemLink,
+} from "@docusaurus/plugin-content-docs/client";
+import { usePluralForm } from "@docusaurus/theme-common";
+import { translate } from "@docusaurus/Translate";
+import type { Props } from "@theme/DocCard";
+import Heading from "@theme/Heading";
+import Markdown from "@theme/Markdown";
+import clsx from "clsx";
+
+import styles from "./styles.module.css";
+
+function useCategoryItemsPlural() {
+  const { selectMessage } = usePluralForm();
+  return (count: number) =>
+    selectMessage(
+      count,
+      translate(
+        {
+          message: "1 item|{count} items",
+          id: "theme.docs.DocCard.categoryDescription.plurals",
+          description:
+            "The default description for a category card in the generated index about how many items this category includes",
+        },
+        { count }
+      )
+    );
+}
+
+function CardContainer({
+  className,
+  href,
+  children,
+}: {
+  className?: string;
+  href: string;
+  children: ReactNode;
+}): ReactNode {
+  return (
+    <Link
+      href={href}
+      className={clsx("card padding--lg", styles.cardContainer, className)}
+    >
+      {children}
+    </Link>
+  );
+}
+
+function CardLayout({
+  className,
+  href,
+  icon,
+  title,
+  description,
+}: {
+  className?: string;
+  href: string;
+  icon: ReactNode;
+  title: string;
+  description?: string;
+}): ReactNode {
+  return (
+    <CardContainer href={href} className={className}>
+      <Heading
+        as="h2"
+        className={clsx("text--truncate", styles.cardTitle)}
+        title={title}
+      >
+        {icon} {title}
+      </Heading>
+      {description && (
+        <p
+          className={clsx("text--truncate", styles.cardDescription)}
+          title={description}
+        >
+          <Markdown>{description}</Markdown>
+        </p>
+      )}
+    </CardContainer>
+  );
+}
+
+function CardCategory({ item }: { item: PropSidebarItemCategory }): ReactNode {
+  const href = findFirstSidebarItemLink(item);
+  const categoryItemsPlural = useCategoryItemsPlural();
+
+  // Unexpected: categories that don't have a link have been filtered upfront
+  if (!href) {
+    return null;
+  }
+
+  return (
+    <CardLayout
+      className={item.className}
+      href={href}
+      icon="🗃️"
+      title={item.label}
+      description={item.description ?? categoryItemsPlural(item.items.length)}
+    />
+  );
+}
+
+function CardLink({ item }: { item: PropSidebarItemLink }): ReactNode {
+  const icon = isInternalUrl(item.href) ? "📄️" : "🔗";
+  const doc = useDocById(item.docId ?? undefined);
+  return (
+    <CardLayout
+      className={item.className}
+      href={item.href}
+      icon={icon}
+      title={item.label}
+      description={item.description ?? doc?.description}
+    />
+  );
+}
+
+export default function DocCard({ item }: Props): ReactNode {
+  switch (item.type) {
+    case "link":
+      return <CardLink item={item} />;
+    case "category":
+      return <CardCategory item={item} />;
+    default:
+      throw new Error(`unknown item type ${JSON.stringify(item)}`);
+  }
+}


### PR DESCRIPTION
## Summary
- create DocCard theme override
- render description with Markdown

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6865458e757483238f3968499b204df5