### PR TITLE
Fix curl tab highlight color

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeTabs/_CodeTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeTabs/_CodeTabs.scss
@@ -197,7 +197,11 @@ body[class="ReactModal__Body--open"] {
   }
 
   &.active {
-    box-shadow: 0 0 0 3px var(--openapi-code-tab-shadow-color-curl);
+    box-shadow: 0 0 0 3px
+      var(
+        --openapi-code-tab-shadow-color-curl,
+        var(--openapi-code-tab-shadow-color-bash)
+      );
     border-color: var(--ifm-color-danger);
   }
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
@@ -67,6 +67,9 @@
   --openapi-code-tab-border-color-java: #0374bd;
   --openapi-code-tab-border-color-powershell: #00adef;
   --openapi-code-tab-shadow-color-python: rgba(255, 219, 80, 0.25);
+  --openapi-code-tab-shadow-color-curl: var(
+    --openapi-code-tab-shadow-color-bash
+  );
   --openapi-code-tab-shadow-color-bash: rgba(250, 56, 62, 0.25);
   --openapi-code-tab-shadow-color-go: rgba(84, 199, 236, 0.25);
   --openapi-code-tab-shadow-color-js: rgba(255, 186, 0, 0.25);


### PR DESCRIPTION
## Summary
- support both `--openapi-code-tab-shadow-color-curl` and `--openapi-code-tab-shadow-color-bash` for curl tab highlights

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68654fe5582c83239d97b54ce77a9633