### PR TITLE
Apply security hardening to workflows

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -13,6 +13,8 @@ jobs:
     name: Build Size Report
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
@@ -34,6 +36,8 @@ jobs:
     name: Build Time Perf
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -17,12 +17,19 @@ jobs:
     steps:
       - name: Check if actor is org member
         id: is-org-member
-        run: echo "is-org-member-result=$(gh api -X GET orgs/PaloAltoNetworks/memberships/${{ github.actor }} | jq -r .message)" >> "$GITHUB_OUTPUT"
-    env:
-      GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          status=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $GH_TOKEN" \
+            https://api.github.com/orgs/PaloAltoNetworks/members/${{ github.actor }})
+          if [ "$status" = "204" ]; then
+            echo "is-org-member-result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-org-member-result=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
 
   analyze:
-    if: github.repository == 'PaloAltoNetworks/docusaurus-openapi-docs' && needs.precheck.outputs.is-org-member-result == 'null'
+    if: github.repository == 'PaloAltoNetworks/docusaurus-openapi-docs' && needs.precheck.outputs.is-org-member-result == 'true'
     name: Analyze
     needs: precheck
     runs-on: ubuntu-latest
@@ -50,7 +57,7 @@ jobs:
         uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3
 
   analyze_unsafe:
-    if: github.repository == 'PaloAltoNetworks/docusaurus-openapi-docs' && needs.precheck.outputs.is-org-member-result != 'null'
+    if: github.repository == 'PaloAltoNetworks/docusaurus-openapi-docs' && needs.precheck.outputs.is-org-member-result == 'false'
     name: Analyze Unsafe
     needs: precheck
     runs-on: ubuntu-latest

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -22,7 +22,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
-          node-version: "*"
+          node-version: "20"
           registry-url: "https://registry.npmjs.org"
       - name: Release Beta
         run: npx ts-node --transpile-only scripts/publish-beta.ts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
-          node-version: "*"
+          node-version: "20"
           registry-url: "https://registry.npmjs.org"
       - name: Release
         run: npx ts-node --transpile-only scripts/publish.ts

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -14,6 +14,8 @@ jobs:
     if: ${{ github.repository == 'PaloAltoNetworks/docusaurus-openapi-docs' }}
     name: Prepare Cache
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
@@ -34,6 +36,8 @@ jobs:
     name: Lint
     needs: prepare-yarn-cache
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
@@ -57,6 +61,8 @@ jobs:
     name: Test
     needs: prepare-yarn-cache
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
@@ -78,6 +84,8 @@ jobs:
     name: Cypress
     needs: prepare-yarn-cache
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4


### PR DESCRIPTION
## Summary
- limit default token permissions for validation and perf builds
- pin Node runtime for release workflows
- check org membership correctly in PR previews

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6875581856c08323b70786a132582877