### PR TITLE
feat: translate additional labels

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
@@ -13,7 +13,7 @@ Array [
     <div style={{ marginLeft: \\"1rem\\" }}>
       <div>
         <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-          oneOf
+          <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
         </span>
         <SchemaTabs>
           <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -399,7 +399,7 @@ Array [
     <div style={{ marginLeft: \\"1rem\\" }}>
       <div>
         <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-          anyOf
+          <Translate id=\\"theme.schema.anyOf\\">anyOf</Translate>
         </span>
         <SchemaTabs>
           <TabItem label={\\"An int or a bool\\"} value={\\"0-item-properties\\"}>
@@ -408,7 +408,7 @@ Array [
                 className={\\"badge badge--info\\"}
                 style={{ marginBottom: \\"1rem\\" }}
               >
-                oneOf
+                <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
               </span>
               <SchemaTabs>
                 <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -451,7 +451,7 @@ Array [
     <div style={{ marginLeft: \\"1rem\\" }}>
       <div>
         <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-          anyOf
+          <Translate id=\\"theme.schema.anyOf\\">anyOf</Translate>
         </span>
         <SchemaTabs>
           <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -477,7 +477,7 @@ exports[`createNodes discriminator should handle basic discriminator with mappin
 Array [
   "<div>
   <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-    oneOf
+    <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -554,7 +554,7 @@ exports[`createNodes discriminator should handle basic discriminator with oneOf 
 Array [
   "<div>
   <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-    oneOf
+    <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -612,7 +612,7 @@ exports[`createNodes discriminator should handle discriminator with additional p
 Array [
   "<div>
   <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-    oneOf
+    <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -679,7 +679,7 @@ Array [
 ",
   "<div>
   <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-    oneOf
+    <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -774,7 +774,7 @@ Array [
 ",
   "<div>
   <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-    oneOf
+    <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -860,7 +860,7 @@ exports[`createNodes discriminator should handle discriminator with nested schem
 Array [
   "<div>
   <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-    oneOf
+    <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -958,7 +958,7 @@ exports[`createNodes discriminator should handle discriminator with required pro
 Array [
   "<div>
   <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-    oneOf
+    <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -1016,7 +1016,7 @@ exports[`createNodes discriminator should handle discriminator with required pro
 Array [
   "<div>
   <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-    oneOf
+    <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -1093,7 +1093,7 @@ exports[`createNodes discriminator should handle discriminator with shared prope
 Array [
   "<div>
   <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-    oneOf
+    <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -1160,7 +1160,7 @@ exports[`createNodes discriminator should handle discriminator with shared prope
 Array [
   "<div>
   <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-    oneOf
+    <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -1255,7 +1255,7 @@ Array [
     <div style={{ marginLeft: \\"1rem\\" }}>
       <div>
         <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-          oneOf
+          <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
         </span>
         <SchemaTabs>
           <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -1345,7 +1345,7 @@ Array [
     <div style={{ marginLeft: \\"1rem\\" }}>
       <div>
         <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-          oneOf
+          <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
         </span>
         <SchemaTabs>
           <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -1365,7 +1365,7 @@ Array [
                       className={\\"badge badge--info\\"}
                       style={{ marginBottom: \\"1rem\\" }}
                     >
-                      oneOf
+                      <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
                     </span>
                     <SchemaTabs>
                       <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -1415,7 +1415,7 @@ Array [
     <div style={{ marginLeft: \\"1rem\\" }}>
       <div>
         <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-          oneOf
+          <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
         </span>
         <SchemaTabs>
           <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -1478,7 +1478,7 @@ Array [
     <div style={{ marginLeft: \\"1rem\\" }}>
       <div>
         <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-          oneOf
+          <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
         </span>
         <SchemaTabs>
           <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -1518,7 +1518,7 @@ Array [
     <div style={{ marginLeft: \\"1rem\\" }}>
       <div>
         <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-          oneOf
+          <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
         </span>
         <SchemaTabs>
           <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
@@ -1572,7 +1572,7 @@ Array [
     <div style={{ marginLeft: \\"1rem\\" }}>
       <div>
         <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
-          oneOf
+          <Translate id=\\"theme.schema.oneOf\\">oneOf</Translate>
         </span>
         <SchemaTabs>
           <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestHeader.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestHeader.ts
@@ -8,17 +8,18 @@
 import { create } from "./utils";
 
 export function createRequestHeader(header: string) {
+  const id = header.replace(" ", "-").toLowerCase();
   return [
-    create(
-      "Heading",
-      {
-        children: header,
-        id: header.replace(" ", "-").toLowerCase(),
-        as: "h2",
-        className: "openapi-tabs__heading",
-      },
-      { inline: true }
-    ),
+    create("Heading", {
+      id,
+      as: "h2",
+      className: "openapi-tabs__heading",
+      children: [
+        `<Translate id="theme.RequestHeader.${id}">`,
+        header,
+        "</Translate>",
+      ],
+    }),
     `\n\n`,
   ];
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -40,11 +40,12 @@ export function mergeAllOf(allOf: SchemaObject) {
  */
 function createAnyOneOf(schema: SchemaObject): any {
   const type = schema.oneOf ? "oneOf" : "anyOf";
+  const translatedType = `<Translate id="theme.schema.${type}">${type}</Translate>`;
   return create("div", {
     children: [
       create("span", {
         className: "badge badge--info",
-        children: type,
+        children: translatedType,
         style: { marginBottom: "1rem" },
       }),
       create("SchemaTabs", {
@@ -375,7 +376,8 @@ function createDetailsNode(
                     () => [
                       create("span", {
                         className: "openapi-schema__required",
-                        children: "required",
+                        children:
+                          '<Translate id="theme.schema.required">required</Translate>',
                       }),
                     ]
                   ),
@@ -530,7 +532,8 @@ function createPropertyDiscriminator(
             guard(required, () => [
               create("span", {
                 className: "openapi-schema__required",
-                children: "required",
+                children:
+                  '<Translate id="theme.schema.required">required</Translate>',
               }),
             ]),
           ],

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -66,6 +66,7 @@ export function createApiPageMD({
   frontMatter,
 }: ApiPageMetadata) {
   return render([
+    `import Translate from "@docusaurus/Translate";\n`,
     `import MethodEndpoint from "@theme/ApiExplorer/MethodEndpoint";\n`,
     `import ParamsDetails from "@theme/ParamsDetails";\n`,
     `import RequestSchema from "@theme/RequestSchema";\n`,

--- a/packages/docusaurus-theme-openapi-docs/src/markdown/schema.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/markdown/schema.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
+import { translate } from "@docusaurus/Translate";
+
 import { SchemaObject } from "../types";
 
 function prettyName(schema: SchemaObject, circular?: boolean) {
@@ -72,7 +74,11 @@ export function getQualifierMessage(schema?: SchemaObject): string | undefined {
     return getQualifierMessage(schema.items);
   }
 
-  let message = "**Possible values:** ";
+  const possibleValues = translate({
+    id: "theme.schema.possibleValues",
+    message: "Possible values:",
+  });
+  let message = `**${possibleValues}** `;
 
   let qualifierGroups = [];
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Authorization/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Authorization/index.tsx
@@ -7,6 +7,7 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
 import FormItem from "@theme/ApiExplorer/FormItem";
 import FormSelect from "@theme/ApiExplorer/FormSelect";
 import FormTextInput from "@theme/ApiExplorer/FormTextInput";
@@ -32,7 +33,12 @@ function Authorization() {
   return (
     <div>
       {optionKeys.length > 1 && (
-        <FormItem label="Security Scheme">
+        <FormItem
+          label={translate({
+            id: "theme.authorization.securityScheme",
+            message: "Security Scheme",
+          })}
+        >
           <FormSelect
             options={optionKeys}
             value={selected}
@@ -45,9 +51,18 @@ function Authorization() {
       {selectedAuth.map((a: any) => {
         if (a.type === "http" && a.scheme === "bearer") {
           return (
-            <FormItem label="Bearer Token" key={a.key + "-bearer"}>
+            <FormItem
+              label={translate({
+                id: "theme.authorization.bearerToken",
+                message: "Bearer Token",
+              })}
+              key={a.key + "-bearer"}
+            >
               <FormTextInput
-                placeholder="Bearer Token"
+                placeholder={translate({
+                  id: "theme.authorization.bearerToken",
+                  message: "Bearer Token",
+                })}
                 password
                 value={data[a.key].token ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
@@ -67,9 +82,18 @@ function Authorization() {
 
         if (a.type === "oauth2") {
           return (
-            <FormItem label="Bearer Token" key={a.key + "-oauth2"}>
+            <FormItem
+              label={translate({
+                id: "theme.authorization.bearerToken",
+                message: "Bearer Token",
+              })}
+              key={a.key + "-oauth2"}
+            >
               <FormTextInput
-                placeholder="Bearer Token"
+                placeholder={translate({
+                  id: "theme.authorization.bearerToken",
+                  message: "Bearer Token",
+                })}
                 password
                 value={data[a.key].token ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
@@ -90,9 +114,17 @@ function Authorization() {
         if (a.type === "http" && a.scheme === "basic") {
           return (
             <React.Fragment key={a.key + "-basic"}>
-              <FormItem label="Username">
+              <FormItem
+                label={translate({
+                  id: "theme.authorization.username",
+                  message: "Username",
+                })}
+              >
                 <FormTextInput
-                  placeholder="Username"
+                  placeholder={translate({
+                    id: "theme.authorization.username",
+                    message: "Username",
+                  })}
                   value={data[a.key].username ?? ""}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     const value = e.target.value;
@@ -106,9 +138,17 @@ function Authorization() {
                   }}
                 />
               </FormItem>
-              <FormItem label="Password">
+              <FormItem
+                label={translate({
+                  id: "theme.authorization.password",
+                  message: "Password",
+                })}
+              >
                 <FormTextInput
-                  placeholder="Password"
+                  placeholder={translate({
+                    id: "theme.authorization.password",
+                    message: "Password",
+                  })}
                   password
                   value={data[a.key].password ?? ""}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormItem/index.tsx
@@ -7,6 +7,7 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
 import clsx from "clsx";
 
 export interface Props {
@@ -24,7 +25,11 @@ function FormItem({ label, type, required, children, className }: Props) {
         <label className="openapi-explorer__form-item-label">{label}</label>
       )}
       {type && <span style={{ opacity: 0.6 }}> — {type}</span>}
-      {required && <span className="openapi-schema__required">required</span>}
+      {required && (
+        <span className="openapi-schema__required">
+          {translate({ id: "theme.schema.required", message: "required" })}
+        </span>
+      )}
       <div>{children}</div>
     </div>
   );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
@@ -6,9 +6,11 @@
  * ========================================================================== */
 
 // @ts-nocheck
+
 import React, { useState } from "react";
 
 import { useDoc } from "@docusaurus/plugin-content-docs/client";
+import { translate } from "@docusaurus/Translate";
 import Accept from "@theme/ApiExplorer/Accept";
 import Authorization from "@theme/ApiExplorer/Authorization";
 import Body from "@theme/ApiExplorer/Body";
@@ -264,7 +266,11 @@ function Request({ item }: { item: ApiItem }) {
                 Body
                 {requestBodyRequired && (
                   <span className="openapi-schema__required">
-                    &nbsp;required
+                    &nbsp;
+                    {translate({
+                      id: "theme.schema.required",
+                      message: "required",
+                    })}
                   </span>
                 )}
               </summary>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/SecuritySchemes/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/SecuritySchemes/index.tsx
@@ -8,6 +8,7 @@
 import React from "react";
 
 import Link from "@docusaurus/Link";
+import { translate } from "@docusaurus/Translate";
 import { useTypedSelector } from "@theme/ApiItem/hooks";
 
 function SecuritySchemes(props: any) {
@@ -26,7 +27,11 @@ function SecuritySchemes(props: any) {
     <details className="openapi-security__details" open={false}>
       <summary className="openapi-security__summary-container">
         <h4 className="openapi-security__summary-header">
-          Authorization: {selectedAuth[0].name ?? selectedAuth[0].type}
+          {translate({
+            id: "theme.authorization.label",
+            message: "Authorization:",
+          })}{" "}
+          {selectedAuth[0].name ?? selectedAuth[0].type}
         </h4>
       </summary>
       {selectedAuth.map((auth: any) => {
@@ -48,16 +53,34 @@ function SecuritySchemes(props: any) {
                   }}
                 >
                   <span>
-                    <strong>name:</strong>{" "}
+                    <strong>
+                      {translate({
+                        id: "theme.authorization.name",
+                        message: "name",
+                      })}
+                      :
+                    </strong>{" "}
                     <Link to={infoAuthPath}>{name ?? key}</Link>
                   </span>
                   <span>
-                    <strong>type: </strong>
+                    <strong>
+                      {translate({
+                        id: "theme.authorization.type",
+                        message: "type",
+                      })}
+                      :
+                    </strong>
                     {type}
                   </span>
                   {scopes && scopes.length > 0 && (
                     <span>
-                      <strong>scopes: </strong>
+                      <strong>
+                        {translate({
+                          id: "theme.authorization.scopes",
+                          message: "scopes",
+                        })}
+                        :
+                      </strong>
                       <code>
                         {auth.scopes.length > 0 ? auth.scopes.toString() : "[]"}
                       </code>
@@ -66,7 +89,13 @@ function SecuritySchemes(props: any) {
                   {Object.keys(rest).map((k, i) => {
                     return (
                       <span key={k}>
-                        <strong>{k}: </strong>
+                        <strong>
+                          {translate({
+                            id: `theme.authorization.${k}`,
+                            message: k,
+                          })}
+                          :
+                        </strong>
                         {typeof rest[k] === "object"
                           ? JSON.stringify(rest[k], null, 2)
                           : String(rest[k])}
@@ -89,16 +118,34 @@ function SecuritySchemes(props: any) {
                   }}
                 >
                   <span>
-                    <strong>name:</strong>{" "}
+                    <strong>
+                      {translate({
+                        id: "theme.authorization.name",
+                        message: "name",
+                      })}
+                      :
+                    </strong>{" "}
                     <Link to={infoAuthPath}>{name ?? key}</Link>
                   </span>
                   <span>
-                    <strong>type: </strong>
+                    <strong>
+                      {translate({
+                        id: "theme.authorization.type",
+                        message: "type",
+                      })}
+                      :
+                    </strong>
                     {type}
                   </span>
                   {scopes && scopes.length > 0 && (
                     <span>
-                      <strong>scopes: </strong>
+                      <strong>
+                        {translate({
+                          id: "theme.authorization.scopes",
+                          message: "scopes",
+                        })}
+                        :
+                      </strong>
                       <code>
                         {auth.scopes.length > 0 ? auth.scopes.toString() : "[]"}
                       </code>
@@ -107,7 +154,13 @@ function SecuritySchemes(props: any) {
                   {Object.keys(rest).map((k, i) => {
                     return (
                       <span key={k}>
-                        <strong>{k}: </strong>
+                        <strong>
+                          {translate({
+                            id: `theme.authorization.${k}`,
+                            message: k,
+                          })}
+                          :
+                        </strong>
                         {typeof rest[k] === "object"
                           ? JSON.stringify(rest[k], null, 2)
                           : String(rest[k])}
@@ -128,15 +181,30 @@ function SecuritySchemes(props: any) {
                 }}
               >
                 <span>
-                  <strong>name:</strong>{" "}
+                  <strong>
+                    {translate({
+                      id: "theme.authorization.name",
+                      message: "name",
+                    })}
+                    :
+                  </strong>{" "}
                   <Link to={infoAuthPath}>{auth.name ?? auth.key}</Link>
                 </span>
                 <span>
-                  <strong>type: </strong>
+                  <strong>
+                    {translate({
+                      id: "theme.authorization.type",
+                      message: "type",
+                    })}
+                    :
+                  </strong>
                   {auth.type}
                 </span>
                 <span>
-                  <strong>in: </strong>
+                  <strong>
+                    {translate({ id: "theme.authorization.in", message: "in" })}
+                    :
+                  </strong>
                   {auth.in}
                 </span>
               </pre>
@@ -156,16 +224,34 @@ function SecuritySchemes(props: any) {
                 }}
               >
                 <span>
-                  <strong>name:</strong>{" "}
+                  <strong>
+                    {translate({
+                      id: "theme.authorization.name",
+                      message: "name",
+                    })}
+                    :
+                  </strong>{" "}
                   <Link to={infoAuthPath}>{name ?? key}</Link>
                 </span>
                 <span>
-                  <strong>type: </strong>
+                  <strong>
+                    {translate({
+                      id: "theme.authorization.type",
+                      message: "type",
+                    })}
+                    :
+                  </strong>
                   {type}
                 </span>
                 {scopes && scopes.length > 0 && (
                   <span>
-                    <strong>scopes: </strong>
+                    <strong>
+                      {translate({
+                        id: "theme.authorization.scopes",
+                        message: "scopes",
+                      })}
+                      :
+                    </strong>
                     <code>
                       {auth.scopes.length > 0 ? auth.scopes.toString() : "[]"}
                     </code>
@@ -174,7 +260,13 @@ function SecuritySchemes(props: any) {
                 {Object.keys(rest).map((k, i) => {
                   return (
                     <span key={k}>
-                      <strong>{k}: </strong>
+                      <strong>
+                        {translate({
+                          id: `theme.authorization.${k}`,
+                          message: k,
+                        })}
+                        :
+                      </strong>
                       {typeof rest[k] === "object"
                         ? JSON.stringify(rest[k], null, 2)
                         : String(rest[k])}
@@ -198,16 +290,34 @@ function SecuritySchemes(props: any) {
                 }}
               >
                 <span>
-                  <strong>name:</strong>{" "}
+                  <strong>
+                    {translate({
+                      id: "theme.authorization.name",
+                      message: "name",
+                    })}
+                    :
+                  </strong>{" "}
                   <Link to={infoAuthPath}>{name ?? key}</Link>
                 </span>
                 <span>
-                  <strong>type: </strong>
+                  <strong>
+                    {translate({
+                      id: "theme.authorization.type",
+                      message: "type",
+                    })}
+                    :
+                  </strong>
                   {type}
                 </span>
                 {scopes && scopes.length > 0 && (
                   <span>
-                    <strong>scopes: </strong>
+                    <strong>
+                      {translate({
+                        id: "theme.authorization.scopes",
+                        message: "scopes",
+                      })}
+                      :
+                    </strong>
                     <code>
                       {auth.scopes.length > 0 ? auth.scopes.toString() : "[]"}
                     </code>
@@ -216,7 +326,13 @@ function SecuritySchemes(props: any) {
                 {Object.keys(rest).map((k, i) => {
                   return (
                     <span key={k}>
-                      <strong>{k}: </strong>
+                      <strong>
+                        {translate({
+                          id: `theme.authorization.${k}`,
+                          message: k,
+                        })}
+                        :
+                      </strong>
                       {typeof rest[k] === "object"
                         ? JSON.stringify(rest[k], null, 2)
                         : String(rest[k])}
@@ -226,7 +342,13 @@ function SecuritySchemes(props: any) {
                 {flows && (
                   <span>
                     <code>
-                      <strong>flows: </strong>
+                      <strong>
+                        {translate({
+                          id: "theme.authorization.flows",
+                          message: "flows",
+                        })}
+                        :
+                      </strong>
                       {JSON.stringify(flows, null, 2)}
                     </code>
                   </span>
@@ -248,16 +370,34 @@ function SecuritySchemes(props: any) {
                 }}
               >
                 <span>
-                  <strong>name:</strong>{" "}
+                  <strong>
+                    {translate({
+                      id: "theme.authorization.name",
+                      message: "name",
+                    })}
+                    :
+                  </strong>{" "}
                   <Link to={infoAuthPath}>{name ?? key}</Link>
                 </span>
                 <span>
-                  <strong>type: </strong>
+                  <strong>
+                    {translate({
+                      id: "theme.authorization.type",
+                      message: "type",
+                    })}
+                    :
+                  </strong>
                   {type}
                 </span>
                 {scopes && scopes.length > 0 && (
                   <span>
-                    <strong>scopes: </strong>
+                    <strong>
+                      {translate({
+                        id: "theme.authorization.scopes",
+                        message: "scopes",
+                      })}
+                      :
+                    </strong>
                     <code>
                       {auth.scopes.length > 0 ? auth.scopes.toString() : "[]"}
                     </code>
@@ -266,7 +406,13 @@ function SecuritySchemes(props: any) {
                 {Object.keys(rest).map((k, i) => {
                   return (
                     <span key={k}>
-                      <strong>{k}: </strong>
+                      <strong>
+                        {translate({
+                          id: `theme.authorization.${k}`,
+                          message: k,
+                        })}
+                        :
+                      </strong>
                       {typeof rest[k] === "object"
                         ? JSON.stringify(rest[k], null, 2)
                         : String(rest[k])}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.tsx
@@ -7,6 +7,7 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
 import Markdown from "@theme/Markdown";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
@@ -39,7 +40,15 @@ export interface Props {
 
 const getEnumDescriptionMarkdown = (enumDescriptions?: [string, string][]) => {
   if (enumDescriptions?.length) {
-    return `| Enum Value | Description |
+    const enumHeader = translate({
+      id: "theme.enum.value",
+      message: "Enum Value",
+    });
+    const descHeader = translate({
+      id: "theme.enum.description",
+      message: "Description",
+    });
+    return `| ${enumHeader} | ${descHeader} |
 | ---- | ----- |
 ${enumDescriptions
   .map((desc) => {
@@ -87,7 +96,9 @@ function ParamsItem({ param, ...rest }: Props) {
   ));
 
   const renderSchemaRequired = guard(required, () => (
-    <span className="openapi-schema__required">required</span>
+    <span className="openapi-schema__required">
+      {translate({ id: "theme.schema.required", message: "required" })}
+    </span>
   ));
 
   const renderDeprecated = guard(deprecated, () => (

--- a/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
@@ -8,6 +8,7 @@
 import React from "react";
 
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import { translate } from "@docusaurus/Translate";
 import Details from "@theme/Details";
 import Markdown from "@theme/Markdown";
 import MimeTabs from "@theme/MimeTabs"; // Assume these components exist
@@ -64,10 +65,16 @@ const RequestSchemaComponent: React.FC<Props> = ({ title, body, style }) => {
                   <>
                     <summary>
                       <h3 className="openapi-markdown__details-summary-header-body">
-                        {title}
+                        {translate({
+                          id: `theme.RequestSchema.${title.toLowerCase()}`,
+                          message: title,
+                        })}
                         {body.required === true && (
                           <span className="openapi-schema__required">
-                            required
+                            {translate({
+                              id: "theme.schema.required",
+                              message: "required",
+                            })}
                           </span>
                         )}
                       </h3>
@@ -114,13 +121,19 @@ const RequestSchemaComponent: React.FC<Props> = ({ title, body, style }) => {
             <>
               <summary>
                 <h3 className="openapi-markdown__details-summary-header-body">
-                  {title}
+                  {translate({
+                    id: `theme.RequestSchema.${title.toLowerCase()}`,
+                    message: title,
+                  })}
                   {firstBody.type === "array" && (
                     <span style={{ opacity: "0.6" }}> array</span>
                   )}
                   {body.required && (
                     <strong className="openapi-schema__required">
-                      required
+                      {translate({
+                        id: "theme.schema.required",
+                        message: "required",
+                      })}
                     </strong>
                   )}
                 </h3>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSchema/index.tsx
@@ -8,6 +8,7 @@
 import React from "react";
 
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import { translate } from "@docusaurus/Translate";
 import Details from "@theme/Details";
 import Markdown from "@theme/Markdown";
 import MimeTabs from "@theme/MimeTabs"; // Assume these components exist
@@ -86,7 +87,10 @@ const ResponseSchemaComponent: React.FC<Props> = ({
                               {title}
                               {body.required === true && (
                                 <span className="openapi-schema__required">
-                                  required
+                                  {translate({
+                                    id: "theme.schema.required",
+                                    message: "required",
+                                  })}
                                 </span>
                               )}
                             </strong>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -7,6 +7,7 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
 import { ClosingArrayBracket, OpeningArrayBracket } from "@theme/ArrayBrackets";
 import Details from "@theme/Details";
 import DiscriminatorTabs from "@theme/DiscriminatorTabs";
@@ -91,7 +92,9 @@ const Summary: React.FC<SummaryProps> = ({
         )}
         {nullable && <span className="openapi-schema__nullable">nullable</span>}
         {isRequired && (
-          <span className="openapi-schema__required">required</span>
+          <span className="openapi-schema__required">
+            {translate({ id: "theme.schema.required", message: "required" })}
+          </span>
         )}
         {deprecated && (
           <span className="openapi-schema__deprecated">deprecated</span>
@@ -109,10 +112,14 @@ interface SchemaProps {
 
 const AnyOneOf: React.FC<SchemaProps> = ({ schema, schemaType }) => {
   const type = schema.oneOf ? "oneOf" : "anyOf";
+  const translatedType = translate({
+    id: `theme.schema.${type}`,
+    message: type,
+  });
   return (
     <>
       <span className="badge badge--info" style={{ marginBottom: "1rem" }}>
-        {type}
+        {translatedType}
       </span>
       <SchemaTabs>
         {schema[type]?.map((anyOneSchema: any, index: number) => {
@@ -254,7 +261,12 @@ const PropertyDiscriminator: React.FC<SchemaEdgeProps> = ({
             )}
             {required && <span className="openapi-schema__divider"></span>}
             {required && (
-              <span className="openapi-schema__required">required</span>
+              <span className="openapi-schema__required">
+                {translate({
+                  id: "theme.schema.required",
+                  message: "required",
+                })}
+              </span>
             )}
           </span>
           <div style={{ marginLeft: "1rem" }}>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
@@ -7,6 +7,7 @@
 
 import React, { ReactNode } from "react";
 
+import { translate } from "@docusaurus/Translate";
 import Markdown from "@theme/Markdown";
 import clsx from "clsx";
 
@@ -36,7 +37,15 @@ const transformEnumDescriptions = (
 
 const getEnumDescriptionMarkdown = (enumDescriptions?: [string, string][]) => {
   if (enumDescriptions?.length) {
-    return `| Enum Value | Description |
+    const enumHeader = translate({
+      id: "theme.enum.value",
+      message: "Enum Value",
+    });
+    const descHeader = translate({
+      id: "theme.enum.description",
+      message: "Description",
+    });
+    return `| ${enumHeader} | ${descHeader} |
 | ---- | ----- |
 ${enumDescriptions
   .map((desc) => {
@@ -81,7 +90,11 @@ export default function SchemaItem(props: Props) {
 
   const renderRequired = guard(
     Array.isArray(required) ? required.includes(name) : required,
-    () => <span className="openapi-schema__required">required</span>
+    () => (
+      <span className="openapi-schema__required">
+        {translate({ id: "theme.schema.required", message: "required" })}
+      </span>
+    )
   );
 
   const renderDeprecated = guard(deprecated, () => (


### PR DESCRIPTION
## Summary
- localize request and body labels across request and response schemas
- translate authorization form fields and schema required badges
- support translated enum tables, possible value notices, and oneOf/anyOf badges

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68acb3e277d08323928d037eafdaef38