### PR TITLE
feat: add CLI flag for schema-only doc generation

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -41,10 +41,10 @@ jobs:
             for (const pull of pulls) {
               const branch = pull['head']['ref'];
               console.log('Pull for branch: ' + branch);
-              if (branch.startsWith('${{ github.event.inputs.branchPrefix }}')) {
+              if (branch.startsWith('${process.env.BRANCH_PREFIX}')) {
                 console.log('Branch matched: ' + branch);
                 statusOK = true;
-                if(${{ github.event.inputs.mustBeGreen }}) {
+                if("true" == process.env.MUST_BE_GREEN}) {
                   console.log('Checking green status: ' + branch);
                   const statuses = await github.paginate('GET /repos/{owner}/{repo}/commits/{ref}/status', {
                     owner: context.repo.owner,
@@ -65,7 +65,7 @@ jobs:
                 for(const label of labels) {
                   const labelName = label['name'];
                   console.log('Checking label: ' + labelName);
-                  if(labelName == '${{ github.event.inputs.ignoreLabel }}') {
+                  if(labelName == '${process.env.IGNORE_LABEL}') {
                     console.log('Discarding ' + branch + ' with label ' + labelName);
                     statusOK = false;
                   }
@@ -88,6 +88,10 @@ jobs:
             combined = branches.join(' ')
             console.log('Combined: ' + combined);
             return combined
+        env:
+          BRANCH_PREFIX: ${{ github.event.inputs.branchPrefix }}
+          MUST_BE_GREEN: ${{ github.event.inputs.mustBeGreen }}
+          IGNORE_LABEL: ${{ github.event.inputs.ignoreLabel }}
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
@@ -126,6 +130,8 @@ jobs:
         name: Create Combined Pull Request
         env:
           PRS_STRING: ${{ steps.fetch-branch-names.outputs.prs-string }}
+          COMBINE_BRANCH_NAME: ${{ github.event.inputs.combineBranchName }}
+          BASE_BRANCH: ${{ steps.fetch-branch-names.outputs.base-branch }}
         with:
           github-token: ${{ steps.get_token.outputs.app_token }}
           script: |
@@ -135,7 +141,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: '🛡️ Security Updates',
-              head: '${{ github.event.inputs.combineBranchName }}',
-              base: '${{ steps.fetch-branch-names.outputs.base-branch }}',
+              head: '${process.env.COMBINE_BRANCH_NAME}',
+              base: '${process.env.BASE_BRANCH}',
               body: body
             });

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -50,7 +50,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Check format
         run: yarn format
       - name: Lint
@@ -75,7 +75,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Test
         run: yarn test
 
@@ -99,7 +99,7 @@ jobs:
             /home/runner/.cache/Cypress
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Build
         run: yarn build
       - name: Cypress

--- a/README.md
+++ b/README.md
@@ -307,6 +307,16 @@ yarn docusaurus gen-api-docs all --all-versions
 
 > This will generate API docs for all versions of all the OpenAPI specification (OAS) files referenced in your `docusaurus-plugin-openapi-docs` config.
 
+To generate only schema MDX files—without updating the sidebar or requiring `showSchemas` in your plugin config—use the `--schemas-only` flag:
+
+```bash
+yarn docusaurus gen-api-docs petstore --schemas-only
+```
+
+> This command writes the schema pages to the configured output directory while leaving other generated docs untouched.
+
+The `--schemas-only` flag is also available for `gen-api-docs:version`.
+
 ### Cleaning API Docs
 
 To clean/remove all API Docs, run the following command from the root directory of your project:

--- a/README.md
+++ b/README.md
@@ -349,6 +349,14 @@ yarn docusaurus clean-api-docs all --all-versions
 
 > This will clean API docs for all versions of all the OpenAPI specification (OAS) files referenced in your `docusaurus-plugin-openapi-docs` config.
 
+To clean only schema docs while leaving API, info, and tag docs untouched, use the `--schemas-only` flag:
+
+```bash
+yarn docusaurus clean-api-docs petstore --schemas-only
+```
+
+> The `--schemas-only` flag is also available for `clean-api-docs:version`.
+
 ### Versioning OpenAPI docs
 
 To generate _all_ versioned OpenAPI docs, run the following command from the root directory of your project:

--- a/README.md
+++ b/README.md
@@ -155,25 +155,25 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 
 `config` can be configured with the following options:
 
-| Name                 | Type      | Default | Description                                                                                                                 |
-| -------------------- | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `specPath`           | `string`  | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of multiple OpenAPI specification files. |
-| `outputDir`          | `string`  | `null`  | Desired output path for generated MDX and sidebar files.                                                                    |
-| `proxy`              | `string`  | `null`  | _Optional:_ Proxy URL to prepend to base URL when performing API requests from browser.                                     |
-| `template`           | `string`  | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                  |
-| `infoTemplate`       | `string`  | `null`  | _Optional:_ Customize MDX content for **info** pages only.                                                                  |
-| `tagTemplate`        | `string`  | `null`  | _Optional:_ Customize MDX content for **tag** pages only.                                                                   |
-| `schemaTemplate`     | `string`  | `null`  | _Optional:_ Customize MDX content for **schema** pages only.                                                                |
-| `downloadUrl`        | `string`  | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                             |
-| `hideSendButton`     | `boolean` | `null`  | _Optional:_ If set to `true`, hides the “Send API Request” button in the API demo panel.                                    |
-| `showExtensions`     | `boolean` | `null`  | _Optional:_ If set to `true`, renders operation‑level vendor‑extensions in descriptions.                                    |
-| `sidebarOptions`     | `object`  | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                            |
-| `version`            | `string`  | `null`  | _Optional:_ Version assigned to a single or micro‑spec API specified in `specPath`.                                         |
-| `label`              | `string`  | `null`  | _Optional:_ Version label used when generating the version‑selector dropdown menu.                                          |
-| `baseUrl`            | `string`  | `null`  | _Optional:_ Base URL for versioned docs in the version‑selector dropdown.                                                   |
-| `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                |
-| `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                       |
-| `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                               |
+| Name                 | Type      | Default | Description                                                                                                                                 |
+| -------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `specPath`           | `string`  | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of multiple OpenAPI specification files.                 |
+| `outputDir`          | `string`  | `null`  | Desired output path for generated MDX and sidebar files.                                                                                    |
+| `proxy`              | `string`  | `null`  | _Optional:_ Proxy URL to prepend to base URL when performing API requests from browser. Overrides site-wide `themeConfig.api.proxy` if set. |
+| `template`           | `string`  | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                                  |
+| `infoTemplate`       | `string`  | `null`  | _Optional:_ Customize MDX content for **info** pages only.                                                                                  |
+| `tagTemplate`        | `string`  | `null`  | _Optional:_ Customize MDX content for **tag** pages only.                                                                                   |
+| `schemaTemplate`     | `string`  | `null`  | _Optional:_ Customize MDX content for **schema** pages only.                                                                                |
+| `downloadUrl`        | `string`  | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                                             |
+| `hideSendButton`     | `boolean` | `null`  | _Optional:_ If set to `true`, hides the “Send API Request” button in the API demo panel.                                                    |
+| `showExtensions`     | `boolean` | `null`  | _Optional:_ If set to `true`, renders operation‑level vendor‑extensions in descriptions.                                                    |
+| `sidebarOptions`     | `object`  | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                                            |
+| `version`            | `string`  | `null`  | _Optional:_ Version assigned to a single or micro‑spec API specified in `specPath`.                                                         |
+| `label`              | `string`  | `null`  | _Optional:_ Version label used when generating the version‑selector dropdown menu.                                                          |
+| `baseUrl`            | `string`  | `null`  | _Optional:_ Base URL for versioned docs in the version‑selector dropdown.                                                                   |
+| `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                                |
+| `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                       |
+| `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                               |
 
 ### sidebarOptions
 
@@ -220,6 +220,31 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | Name            | Type       | Default | Description                                                                                                                                                                                                                                      |
 | --------------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `createDocItem` | `function` | `null`  | Optional: Returns a `SidebarItemDoc` object containing metadata for a sidebar item.<br/><br/>**Function type:** `(item: ApiPageMetadata \| SchemaPageMetadata, context: { sidebarOptions: SidebarOptions; basePath: string }) => SidebarItemDoc` |
+
+## Theme Configuration Options
+
+The `docusaurus-theme-openapi-docs` theme can be configured with the following options in `themeConfig.api`:
+
+| Name              | Type     | Default | Description                                                                                                                        |
+| ----------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `proxy`           | `string` | `null`  | _Optional:_ Site-wide proxy URL to prepend to base URL when performing API requests. Can be overridden per-spec via plugin config. |
+| `authPersistance` | `string` | `null`  | _Optional:_ Determines how auth credentials are persisted. Options: `"localStorage"`, `"sessionStorage"`, or `false` to disable.   |
+| `requestTimeout`  | `number` | `30000` | _Optional:_ Request timeout in milliseconds for API requests made from the browser. Defaults to 30 seconds.                        |
+
+Example:
+
+```typescript
+// docusaurus.config.ts
+{
+  themeConfig: {
+    api: {
+      proxy: "https://cors.pan.dev",  // Site-wide proxy (can be overridden per-spec in plugin config)
+      authPersistance: "localStorage",
+      requestTimeout: 60000, // 60 seconds
+    },
+  },
+}
+```
 
 ## CLI Usage
 

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -363,6 +363,14 @@ Example:
 yarn docusaurus gen-api-docs petstore
 ```
 
+To generate only schema MDX files—without updating the sidebar or requiring `showSchemas` in your plugin config—use the `--schemas-only` flag:
+
+```bash title="generating only schema docs for 'petstore'"
+yarn docusaurus gen-api-docs petstore --schemas-only
+```
+
+> This command writes the schema pages to the configured output directory while leaving other generated docs untouched.
+
 ### Cleaning API Docs
 
 To clean/remove all API Docs, run the following command from the root directory of your project:

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -206,7 +206,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | -------------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `specPath`           | `string`  | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of multiple OpenAPI specification files.                     |
 | `outputDir`          | `string`  | `null`  | Desired output path for generated MDX and sidebar files.                                                                                        |
-| `proxy`              | `string`  | `null`  | _Optional:_ Proxy URL to prepend to base URL when performing API requests from browser.                                                         |
+| `proxy`              | `string`  | `null`  | _Optional:_ Proxy URL to prepend to base URL when performing API requests from browser. Overrides site-wide `themeConfig.api.proxy` if set. |
 | `template`           | `string`  | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                                      |
 | `infoTemplate`       | `string`  | `null`  | _Optional:_ Customize MDX content for **info** pages only.                                                                                      |
 | `tagTemplate`        | `string`  | `null`  | _Optional:_ Customize MDX content for **tag** pages only.                                                                                       |
@@ -284,6 +284,31 @@ petstore31: {
 | Name            | Type       | Default | Description                                                                                                                                                                                                                                      |
 | --------------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `createDocItem` | `function` | `null`  | Optional: Returns a `SidebarItemDoc` object containing metadata for a sidebar item.<br/><br/>**Function type:** `(item: ApiPageMetadata \| SchemaPageMetadata, context: { sidebarOptions: SidebarOptions; basePath: string }) => SidebarItemDoc` |
+
+## Theme Configuration Options
+
+The `docusaurus-theme-openapi-docs` theme can be configured with the following options in `themeConfig.api`:
+
+| Name             | Type     | Default | Description                                                                                                                                         |
+| ---------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `proxy`          | `string` | `null`  | _Optional:_ Site-wide proxy URL to prepend to base URL when performing API requests. Can be overridden per-spec via plugin config.                  |
+| `authPersistance`| `string` | `null`  | _Optional:_ Determines how auth credentials are persisted. Options: `"localStorage"`, `"sessionStorage"`, or `false` to disable.                    |
+| `requestTimeout` | `number` | `30000` | _Optional:_ Request timeout in milliseconds for API requests made from the browser. Defaults to 30 seconds.                                         |
+
+Example:
+
+```typescript
+// docusaurus.config.ts
+{
+  themeConfig: {
+    api: {
+      proxy: "https://cors.pan.dev",  // Site-wide proxy (can be overridden per-spec in plugin config)
+      authPersistance: "localStorage",
+      requestTimeout: 60000, // 60 seconds
+    },
+  },
+}
+```
 
 ## CLI Usage
 

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -391,6 +391,12 @@ Example:
 yarn docusaurus clean-api-docs petstore
 ```
 
+To clean only schema docs while leaving API, info, and tag docs untouched, use the `--schemas-only` flag:
+
+```bash title="cleaning only schema docs for 'petstore'"
+yarn docusaurus clean-api-docs petstore --schemas-only
+```
+
 ### Versioning OpenAPI docs
 
 To generate _all_ versioned OpenAPI docs, run the following command from the root directory of your project:

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -371,6 +371,8 @@ yarn docusaurus gen-api-docs petstore --schemas-only
 
 > This command writes the schema pages to the configured output directory while leaving other generated docs untouched.
 
+The `--schemas-only` flag is also available for `gen-api-docs:version`.
+
 ### Cleaning API Docs
 
 To clean/remove all API Docs, run the following command from the root directory of your project:
@@ -396,6 +398,8 @@ To clean only schema docs while leaving API, info, and tag docs untouched, use t
 ```bash title="cleaning only schema docs for 'petstore'"
 yarn docusaurus clean-api-docs petstore --schemas-only
 ```
+
+> The `--schemas-only` flag is also available for `clean-api-docs:version`.
 
 ### Versioning OpenAPI docs
 

--- a/demo/examples/tests/allOf.yaml
+++ b/demo/examples/tests/allOf.yaml
@@ -412,6 +412,205 @@ paths:
                 required:
                   - pet
 
+  /allof-multiple-oneof:
+    post:
+      tags:
+        - allOf
+      summary: allOf with multiple oneOf constraints
+      description: |
+        Schema demonstrating allOf containing multiple independent oneOf constraints.
+        The object must satisfy one option from each oneOf group AND include shared properties.
+
+        This pattern is used when multiple independent constraints must all be satisfied,
+        similar to the security-rules schema where a rule must be one policy type AND exist in one scope.
+
+        Schema:
+        ```yaml
+        type: object
+        allOf:
+          # Constraint 1: Must be one of these types
+          - oneOf:
+              - title: standard
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum: [standard]
+                  priority:
+                    type: integer
+                    minimum: 1
+                    maximum: 10
+                required: [type, priority]
+              - title: express
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum: [express]
+                  expedited:
+                    type: boolean
+                required: [type, expedited]
+          
+          # Constraint 2: Must exist in one of these scopes
+          - oneOf:
+              - title: global
+                type: object
+                properties:
+                  scope:
+                    type: string
+                    enum: [global]
+                required: [scope]
+              - title: regional
+                type: object
+                properties:
+                  scope:
+                    type: string
+                    enum: [regional]
+                  region:
+                    type: string
+                required: [scope, region]
+              - title: local
+                type: object
+                properties:
+                  scope:
+                    type: string
+                    enum: [local]
+                  location:
+                    type: string
+                required: [scope, location]
+
+        # Shared properties that apply regardless of which options are chosen
+        properties:
+          id:
+            type: string
+            format: uuid
+          name:
+            type: string
+          description:
+            type: string
+          enabled:
+            type: boolean
+            default: true
+        required: [id, name]
+        ```
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              allOf:
+                # Constraint 1: Must be one of these types
+                - oneOf:
+                    - title: standard
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          enum: [standard]
+                          description: Standard processing type
+                          example: standard
+                        priority:
+                          type: integer
+                          minimum: 1
+                          maximum: 10
+                          description: Priority level for standard type
+                          example: 5
+                      required: [type, priority]
+                    - title: express
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          enum: [express]
+                          description: Express processing type
+                          example: express
+                        expedited:
+                          type: boolean
+                          description: Enable expedited processing
+                          default: true
+                      required: [type, expedited]
+
+                # Constraint 2: Must exist in one of these scopes
+                - oneOf:
+                    - title: global
+                      type: object
+                      properties:
+                        scope:
+                          type: string
+                          enum: [global]
+                          description: Global scope
+                          example: global
+                      required: [scope]
+                    - title: regional
+                      type: object
+                      properties:
+                        scope:
+                          type: string
+                          enum: [regional]
+                          description: Regional scope
+                          example: regional
+                        region:
+                          type: string
+                          pattern: ^[a-z]{2}-[a-z]+-\d+$
+                          description: AWS-style region identifier
+                          example: us-west-2
+                      required: [scope, region]
+                    - title: local
+                      type: object
+                      properties:
+                        scope:
+                          type: string
+                          enum: [local]
+                          description: Local scope
+                          example: local
+                        location:
+                          type: string
+                          maxLength: 100
+                          description: Specific location identifier
+                          example: datacenter-1
+                      required: [scope, location]
+
+              # Shared properties
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                  description: Unique identifier
+                  example: 123e4567-e89b-12d3-a456-426655440000
+                name:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                  description: Resource name
+                  example: my-resource
+                description:
+                  type: string
+                  maxLength: 1024
+                  description: Optional description
+                  example: This is a test resource
+                enabled:
+                  type: boolean
+                  description: Whether the resource is enabled
+                  default: true
+              required: [id, name]
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  name:
+                    type: string
+                  message:
+                    type: string
+                    example: Resource created successfully
+
 components:
   schemas:
     # Your existing schemas are integrated here.

--- a/demo/examples/tests/anyOf.yaml
+++ b/demo/examples/tests/anyOf.yaml
@@ -123,3 +123,185 @@ paths:
                       example: pencil
                   required:
                     - orderNo
+
+  /anyof-nested-oneof-with-properties:
+    post:
+      tags:
+        - anyOf
+      summary: anyOf with nested oneOf and properties at same level
+      description: |
+        Schema demonstrating complex nested structures where:
+        - An anyOf contains multiple oneOf arrays
+        - oneOf schemas have properties without explicit type
+        - A schema has both oneOf and properties at the same level (layer3)
+
+        This pattern is similar to the ethernet-interfaces schema.
+
+        Schema:
+        ```yaml
+        type: object
+        properties:
+          id:
+            type: string
+          name:
+            type: string
+        anyOf:
+          - oneOf:
+            - title: tap
+              properties:
+                tap:
+                  type: object
+                  default: {}
+            - title: layer2
+              required:
+                - layer2
+              properties:
+                layer2:
+                  type: object
+                  properties:
+                    vlan-tag:
+                      type: integer
+            - title: layer3
+              required:
+                - layer3
+              properties:
+                layer3:
+                  type: object
+                  oneOf:
+                    - title: static
+                      type: object
+                      properties:
+                        ip:
+                          type: array
+                          items:
+                            type: string
+                    - title: dhcp
+                      type: object
+                      properties:
+                        dhcp-enabled:
+                          type: boolean
+                  properties:
+                    mtu:
+                      type: integer
+                      default: 1500
+                    management-profile:
+                      type: string
+          - oneOf:
+            - title: folder
+              type: object
+              properties:
+                folder:
+                  type: string
+              required:
+                - folder
+            - title: snippet
+              type: object
+              properties:
+                snippet:
+                  type: string
+              required:
+                - snippet
+        ```
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: UUID of the resource
+                  example: 123e4567-e89b-12d3-a456-426655440000
+                name:
+                  type: string
+                  description: Interface name
+                  example: ethernet1/1
+              anyOf:
+                - oneOf:
+                    - title: tap
+                      properties:
+                        tap:
+                          type: object
+                          default: {}
+                    - title: layer2
+                      required:
+                        - layer2
+                      properties:
+                        layer2:
+                          type: object
+                          properties:
+                            vlan-tag:
+                              description: Assign interface to VLAN tag
+                              type: integer
+                              minimum: 1
+                              maximum: 4094
+                    - title: layer3
+                      required:
+                        - layer3
+                      properties:
+                        layer3:
+                          type: object
+                          oneOf:
+                            - title: static
+                              type: object
+                              properties:
+                                ip:
+                                  description: Interface IP addresses
+                                  type: array
+                                  items:
+                                    type: string
+                                    example: 192.168.1.1/24
+                            - title: dhcp
+                              type: object
+                              properties:
+                                dhcp-enabled:
+                                  description: Enable DHCP client
+                                  type: boolean
+                                  default: true
+                          properties:
+                            mtu:
+                              description: Maximum transmission unit
+                              type: integer
+                              minimum: 576
+                              maximum: 9216
+                              default: 1500
+                            management-profile:
+                              description: Interface management profile
+                              type: string
+                              maxLength: 31
+                - oneOf:
+                    - type: object
+                      title: folder
+                      properties:
+                        folder:
+                          type: string
+                          pattern: ^[a-zA-Z\d-_\. ]+$
+                          maxLength: 64
+                          description: The folder in which the resource is defined
+                          example: My Folder
+                      required:
+                        - folder
+                    - type: object
+                      title: snippet
+                      properties:
+                        snippet:
+                          type: string
+                          pattern: ^[a-zA-Z\d-_\. ]+$
+                          maxLength: 64
+                          description: The snippet in which the resource is defined
+                          example: My Snippet
+                      required:
+                        - snippet
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -370,6 +370,14 @@ yarn docusaurus clean-api-docs all --all-versions
 
 > This will clean API docs for all versions of all the OpenAPI specification (OAS) files referenced in your `docusaurus-plugin-openapi-docs` config.
 
+To clean only schema docs while leaving API, info, and tag docs untouched, use the `--schemas-only` flag:
+
+```bash
+yarn docusaurus clean-api-docs petstore --schemas-only
+```
+
+> The `--schemas-only` flag is also available for `clean-api-docs:version`.
+
 ### Versioning OpenAPI docs
 
 To generate _all_ versioned OpenAPI docs, run the following command from the root directory of your project:

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -328,6 +328,16 @@ yarn docusaurus gen-api-docs all --all-versions
 
 > This will generate API docs for all versions of all the OpenAPI specification (OAS) files referenced in your `docusaurus-plugin-openapi-docs` config.
 
+To generate only schema MDX files—without updating the sidebar or requiring `showSchemas` in your plugin config—use the `--schemas-only` flag:
+
+```bash
+yarn docusaurus gen-api-docs petstore --schemas-only
+```
+
+> This command writes the schema pages to the configured output directory while leaving other generated docs untouched.
+
+The `--schemas-only` flag is also available for `gen-api-docs:version`.
+
 ### Cleaning API Docs
 
 To clean/remove all API Docs, run the following command from the root directory of your project:

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -156,26 +156,26 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 
 `config` can be configured with the following options:
 
-| Name                 | Type      | Default | Description                                                                                                                             |
-| -------------------- | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `specPath`           | `string`  | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of multiple OpenAPI specification files.             |
-| `outputDir`          | `string`  | `null`  | Desired output path for generated MDX and sidebar files.                                                                                |
-| `proxy`              | `string`  | `null`  | _Optional:_ Proxy URL to prepend to base URL when performing API requests from browser.                                                 |
-| `template`           | `string`  | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                              |
-| `infoTemplate`       | `string`  | `null`  | _Optional:_ Customize MDX content for **info** pages only.                                                                              |
-| `tagTemplate`        | `string`  | `null`  | _Optional:_ Customize MDX content for **tag** pages only.                                                                               |
-| `schemaTemplate`     | `string`  | `null`  | _Optional:_ Customize MDX content for **schema** pages only.                                                                            |
-| `downloadUrl`        | `string`  | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                                         |
-| `hideSendButton`     | `boolean` | `null`  | _Optional:_ If set to `true`, hides the “Send API Request” button in the API demo panel.                                                |
-| `showExtensions`     | `boolean` | `null`  | _Optional:_ If set to `true`, renders operation‑level vendor‑extensions in descriptions.                                                |
-| `maskCredentials`    | `boolean` | `true`  | _Optional:_ If set to `false`, disables credential masking in generated code snippets. By default, credentials are masked for security. |
-| `sidebarOptions`     | `object`  | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                                        |
-| `version`            | `string`  | `null`  | _Optional:_ Version assigned to a single or micro‑spec API specified in `specPath`.                                                     |
-| `label`              | `string`  | `null`  | _Optional:_ Version label used when generating the version‑selector dropdown menu.                                                      |
-| `baseUrl`            | `string`  | `null`  | _Optional:_ Base URL for versioned docs in the version‑selector dropdown.                                                               |
-| `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                            |
-| `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                   |
-| `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                           |
+| Name                 | Type      | Default | Description                                                                                                                                 |
+| -------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `specPath`           | `string`  | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of multiple OpenAPI specification files.                 |
+| `outputDir`          | `string`  | `null`  | Desired output path for generated MDX and sidebar files.                                                                                    |
+| `proxy`              | `string`  | `null`  | _Optional:_ Proxy URL to prepend to base URL when performing API requests from browser. Overrides site-wide `themeConfig.api.proxy` if set. |
+| `template`           | `string`  | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                                  |
+| `infoTemplate`       | `string`  | `null`  | _Optional:_ Customize MDX content for **info** pages only.                                                                                  |
+| `tagTemplate`        | `string`  | `null`  | _Optional:_ Customize MDX content for **tag** pages only.                                                                                   |
+| `schemaTemplate`     | `string`  | `null`  | _Optional:_ Customize MDX content for **schema** pages only.                                                                                |
+| `downloadUrl`        | `string`  | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                                             |
+| `hideSendButton`     | `boolean` | `null`  | _Optional:_ If set to `true`, hides the “Send API Request” button in the API demo panel.                                                    |
+| `showExtensions`     | `boolean` | `null`  | _Optional:_ If set to `true`, renders operation‑level vendor‑extensions in descriptions.                                                    |
+| `maskCredentials`    | `boolean` | `true`  | _Optional:_ If set to `false`, disables credential masking in generated code snippets. By default, credentials are masked for security.     |
+| `sidebarOptions`     | `object`  | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                                            |
+| `version`            | `string`  | `null`  | _Optional:_ Version assigned to a single or micro‑spec API specified in `specPath`.                                                         |
+| `label`              | `string`  | `null`  | _Optional:_ Version label used when generating the version‑selector dropdown menu.                                                          |
+| `baseUrl`            | `string`  | `null`  | _Optional:_ Base URL for versioned docs in the version‑selector dropdown.                                                                   |
+| `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                                |
+| `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                       |
+| `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                               |
 
 ### sidebarOptions
 
@@ -223,6 +223,31 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | Name            | Type       | Default | Description                                                                                                                                                                                                                                      |
 | --------------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `createDocItem` | `function` | `null`  | Optional: Returns a `SidebarItemDoc` object containing metadata for a sidebar item.<br/><br/>**Function type:** `(item: ApiPageMetadata \| SchemaPageMetadata, context: { sidebarOptions: SidebarOptions; basePath: string }) => SidebarItemDoc` |
+
+## Theme Configuration Options
+
+The `docusaurus-theme-openapi-docs` theme can be configured with the following options in `themeConfig.api`:
+
+| Name              | Type     | Default | Description                                                                                                                        |
+| ----------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `proxy`           | `string` | `null`  | _Optional:_ Site-wide proxy URL to prepend to base URL when performing API requests. Can be overridden per-spec via plugin config. |
+| `authPersistance` | `string` | `null`  | _Optional:_ Determines how auth credentials are persisted. Options: `"localStorage"`, `"sessionStorage"`, or `false` to disable.   |
+| `requestTimeout`  | `number` | `30000` | _Optional:_ Request timeout in milliseconds for API requests made from the browser. Defaults to 30 seconds.                        |
+
+Example:
+
+```typescript
+// docusaurus.config.ts
+{
+  themeConfig: {
+    api: {
+      proxy: "https://cors.pan.dev",  // Site-wide proxy (can be overridden per-spec in plugin config)
+      authPersistance: "localStorage",
+      requestTimeout: 60000, // 60 seconds
+    },
+  },
+}
+```
 
 ## Supported Vendor Extensions
 

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample.test.ts
@@ -1,0 +1,57 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { sampleFromSchema } from "./createSchemaExample";
+import { SchemaObject } from "./types";
+
+describe("sampleFromSchema", () => {
+  describe("const support", () => {
+    it("should return default string value when const is not present", () => {
+      const schema: SchemaObject = {
+        type: "string",
+      };
+      const context = { type: "request" as const };
+
+      const result = sampleFromSchema(schema, context);
+
+      expect(result).toBe("string");
+    });
+
+    it("should return const value when const is present", () => {
+      const schema: SchemaObject = {
+        type: "string",
+        const: "example",
+      };
+      const context = { type: "request" as const };
+
+      const result = sampleFromSchema(schema, context);
+
+      expect(result).toBe("example");
+    });
+
+    it("should handle anyOf with const values", () => {
+      const schema: SchemaObject = {
+        type: "string",
+        anyOf: [
+          {
+            type: "string",
+            const: "dog",
+          },
+          {
+            type: "string",
+            const: "cat",
+          },
+        ],
+      };
+      const context = { type: "request" as const };
+
+      const result = sampleFromSchema(schema, context);
+
+      expect(result).toBe("dog");
+    });
+  });
+});

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample.ts
@@ -111,7 +111,16 @@ export const sampleFromSchema = (
   try {
     // deep copy schema before processing
     let schemaCopy = JSON.parse(JSON.stringify(schema));
-    let { type, example, allOf, properties, items, oneOf, anyOf } = schemaCopy;
+    let {
+      type,
+      example,
+      allOf,
+      properties,
+      items,
+      oneOf,
+      anyOf,
+      const: constant,
+    } = schemaCopy;
 
     if (example !== undefined) {
       return example;
@@ -216,6 +225,10 @@ export const sampleFromSchema = (
 
     if (shouldExcludeProperty(schemaCopy, context)) {
       return undefined;
+    }
+
+    if (constant) {
+      return constant;
     }
 
     return primitive(schemaCopy);

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
@@ -11,6 +11,8 @@ import path from "path";
 import { posixPath } from "@docusaurus/utils";
 
 import { readOpenapiFiles } from ".";
+import { processOpenapiFile } from "./openapi";
+import type { APIOptions, SidebarOptions } from "../types";
 
 // npx jest packages/docusaurus-plugin-openapi/src/openapi/openapi.test.ts --watch
 
@@ -35,6 +37,62 @@ describe("openapi", () => {
       expect(
         yaml?.data.components?.schemas?.HelloString["x-tags"]
       ).toBeDefined();
+    });
+  });
+
+  describe("schemasOnly", () => {
+    it("includes schema metadata when showSchemas is disabled", async () => {
+      const openapiData = {
+        openapi: "3.0.0",
+        info: {
+          title: "Schema Only",
+          version: "1.0.0",
+        },
+        paths: {
+          "/ping": {
+            get: {
+              summary: "Ping",
+              responses: {
+                "200": {
+                  description: "OK",
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            WithoutTags: {
+              title: "Without Tags",
+              type: "object",
+              properties: {
+                value: {
+                  type: "string",
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const options: APIOptions = {
+        specPath: "dummy", // required by the type but unused in this context
+        outputDir: "build",
+        showSchemas: false,
+        schemasOnly: true,
+      };
+
+      const sidebarOptions = {} as SidebarOptions;
+
+      const [items] = await processOpenapiFile(
+        openapiData as any,
+        options,
+        sidebarOptions
+      );
+
+      const schemaItems = items.filter((item) => item.type === "schema");
+      expect(schemaItems).toHaveLength(1);
+      expect(schemaItems[0].id).toBe("without-tags");
     });
   });
 });

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -95,6 +95,7 @@ function createItems(
   let items: PartialPage<ApiMetadata>[] = [];
   const infoIdSpaces = openapiData.info.title.replace(" ", "-").toLowerCase();
   const infoId = kebabCase(infoIdSpaces);
+  const schemasOnly = options?.schemasOnly === true;
 
   if (openapiData.info.description || openapiData.info.title) {
     // Only create an info page if we have a description.
@@ -434,6 +435,7 @@ function createItems(
   }
 
   if (
+    schemasOnly ||
     options?.showSchemas === true ||
     Object.entries(openapiData?.components?.schemas ?? {})
       .flatMap(([_, s]) => s["x-tags"])
@@ -443,7 +445,11 @@ function createItems(
     for (let [schema, schemaObject] of Object.entries(
       openapiData?.components?.schemas ?? {}
     )) {
-      if (options?.showSchemas === true || schemaObject["x-tags"]) {
+      if (
+        schemasOnly ||
+        options?.showSchemas === true ||
+        schemaObject["x-tags"]
+      ) {
         const baseIdSpaces =
           schemaObject?.title?.replace(" ", "-").toLowerCase() ?? "";
         const baseId = kebabCase(baseIdSpaces);

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -51,6 +51,7 @@ export interface APIOptions {
   proxy?: string;
   markdownGenerators?: MarkdownGenerator;
   showSchemas?: boolean;
+  schemasOnly?: boolean;
   disableCompression?: boolean;
   maskCredentials?: boolean;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx
@@ -76,7 +76,7 @@ function CodeSnippets({
               const authOptions =
                 clonedAuth?.options?.[key] ??
                 clonedAuth?.options?.[comboAuthId];
-              placeholder = authOptions?.[0]?.name;
+              placeholder = authOptions?.find((opt: any) => opt.key === key)?.name;
               obj[key] = cleanCredentials(obj[key]);
             } else {
               obj[key] = `<${placeholder ?? key}>`;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/makeRequest.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/makeRequest.ts
@@ -8,17 +8,83 @@
 import { Body } from "@theme/ApiExplorer/Body/slice";
 import * as sdk from "postman-collection";
 
+// Custom error types for better error handling
+export type RequestErrorType =
+  | "timeout"
+  | "network"
+  | "cors"
+  | "abort"
+  | "unknown";
+
+export class RequestError extends Error {
+  type: RequestErrorType;
+  originalError?: Error;
+
+  constructor(type: RequestErrorType, message: string, originalError?: Error) {
+    super(message);
+    this.name = "RequestError";
+    this.type = type;
+    this.originalError = originalError;
+  }
+}
+
+const DEFAULT_REQUEST_TIMEOUT = 30000; // 30 seconds
+
 function fetchWithtimeout(
   url: string,
   options: RequestInit,
-  timeout = 5000
-): any {
-  return Promise.race([
-    fetch(url, options),
-    new Promise((_, reject) =>
-      setTimeout(() => reject(new Error("Request timed out")), timeout)
-    ),
-  ]);
+  timeout = DEFAULT_REQUEST_TIMEOUT
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  return fetch(url, {
+    ...options,
+    signal: controller.signal,
+  })
+    .then((response) => {
+      clearTimeout(timeoutId);
+      return response;
+    })
+    .catch((error) => {
+      clearTimeout(timeoutId);
+
+      // Check if it was an abort due to timeout
+      if (error.name === "AbortError") {
+        throw new RequestError(
+          "timeout",
+          "The request timed out waiting for the server to respond. Please try again. If the issue persists, try using a different client (e.g., curl) with a longer timeout.",
+          error
+        );
+      }
+
+      // Check for network errors (offline, DNS failure, etc.)
+      if (error instanceof TypeError && error.message === "Failed to fetch") {
+        // This could be CORS, network failure, or the server being unreachable
+        throw new RequestError(
+          "network",
+          "Unable to reach the server. Please check your network connection and verify the server URL is correct. If the server is running, this may be a CORS issue.",
+          error
+        );
+      }
+
+      // Handle other TypeErrors that might indicate CORS issues
+      if (error instanceof TypeError) {
+        throw new RequestError(
+          "cors",
+          "The request was blocked, possibly due to CORS restrictions. Ensure the server allows requests from this origin, or try using a proxy.",
+          error
+        );
+      }
+
+      // Generic error fallback
+      throw new RequestError(
+        "unknown",
+        error.message ||
+          "An unexpected error occurred while making the request.",
+        error
+      );
+    });
 }
 
 async function loadImage(content: Blob): Promise<string | ArrayBuffer | null> {
@@ -47,7 +113,8 @@ async function loadImage(content: Blob): Promise<string | ArrayBuffer | null> {
 async function makeRequest(
   request: sdk.Request,
   proxy: string | undefined,
-  _body: Body
+  _body: Body,
+  timeout: number = DEFAULT_REQUEST_TIMEOUT
 ) {
   const headers = request.toJSON().header;
 
@@ -194,7 +261,8 @@ async function makeRequest(
     finalUrl = normalizedProxy + request.url.toString();
   }
 
-  return fetchWithtimeout(finalUrl, requestOptions).then((response: any) => {
+  try {
+    const response = await fetchWithtimeout(finalUrl, requestOptions, timeout);
     const contentType = response.headers.get("content-type");
     let fileExtension = "";
 
@@ -224,32 +292,45 @@ async function makeRequest(
       }
 
       if (fileExtension) {
-        return response.blob().then((blob: any) => {
-          const url = window.URL.createObjectURL(blob);
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
 
-          const link = document.createElement("a");
-          link.href = url;
-          // Now the file name includes the extension
-          link.setAttribute("download", `file${fileExtension}`);
+        const link = document.createElement("a");
+        link.href = url;
+        // Now the file name includes the extension
+        link.setAttribute("download", `file${fileExtension}`);
 
-          // These two lines are necessary to make the link click in Firefox
-          link.style.display = "none";
-          document.body.appendChild(link);
+        // These two lines are necessary to make the link click in Firefox
+        link.style.display = "none";
+        document.body.appendChild(link);
 
-          link.click();
+        link.click();
 
-          // After link is clicked, it's safe to remove it.
-          setTimeout(() => document.body.removeChild(link), 0);
+        // After link is clicked, it's safe to remove it.
+        setTimeout(() => document.body.removeChild(link), 0);
 
-          return response;
-        });
+        return response;
       } else {
         return response;
       }
     }
 
     return response;
-  });
+  } catch (error) {
+    // Re-throw RequestError instances as-is
+    if (error instanceof RequestError) {
+      throw error;
+    }
+
+    // Wrap unexpected errors
+    throw new RequestError(
+      "unknown",
+      error instanceof Error
+        ? error.message
+        : "An unexpected error occurred while processing the response.",
+      error instanceof Error ? error : undefined
+    );
+  }
 }
 
 export default makeRequest;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.tsx
@@ -115,7 +115,10 @@ function TabList({
   };
 
   return (
-    <div className="openapi-tabs__schema-tabs-container">
+    <div
+      className="openapi-tabs__schema-tabs-container"
+      style={{ marginBottom: "1rem" }}
+    >
       {showTabArrows && (
         <button
           className="openapi-tabs__arrow left"

--- a/packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts
@@ -29,6 +29,10 @@ export const OPENAPI_REQUEST = {
   PARAMETERS_TITLE: "theme.openapi.request.parameters.title",
   FETCHING_MESSAGE: "theme.openapi.request.fetchingMessage",
   CONNECTION_FAILED: "theme.openapi.request.connectionFailed",
+  ERROR_TIMEOUT: "theme.openapi.request.error.timeout",
+  ERROR_NETWORK: "theme.openapi.request.error.network",
+  ERROR_CORS: "theme.openapi.request.error.cors",
+  ERROR_UNKNOWN: "theme.openapi.request.error.unknown",
 };
 
 export const OPENAPI_SERVER = {

--- a/packages/docusaurus-theme-openapi-docs/src/types.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/types.ts
@@ -12,6 +12,8 @@ export interface ThemeConfig {
   api?: {
     proxy?: string;
     authPersistance?: false | "localStorage" | "sessionStorage";
+    /** Request timeout in milliseconds. Defaults to 30000 (30 seconds). */
+    requestTimeout?: number;
   };
 }
 


### PR DESCRIPTION
## Summary
- add a `--schemas-only` flag to the `gen-api-docs` and `gen-api-docs:version` commands and skip sidebar generation when it is used
- allow schema metadata to be produced when the CLI override is set even if `showSchemas` is disabled, and cover the behavior with a test
- document the new flag across the README, plugin README, and demo docs

## Testing
- yarn lint
- CI=1 yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d176ea1eb4832386ce1f558e0a7d7e